### PR TITLE
Handling long integers in the JSON callback.

### DIFF
--- a/rdbtools/callbacks.py
+++ b/rdbtools/callbacks.py
@@ -72,7 +72,7 @@ def _encode(s, quote_numbers = True):
         qn = '"'
     else:
         qn = ''
-    if isinstance(s, int):
+    if isinstance(s, int) or isinstance(s, long):
         return qn + str(s) + qn
     elif isinstance(s, float):
         if s != s:


### PR DESCRIPTION
One of our Redis databases has integers that use the "long" type in Python. That caused the _encode function in callbacks.py to call _encode_basestring_ascii on a long object, which fails. I just modified the initial conditional to look for longs. The only other Python numeric type of which I'm aware is "complex", which I don't think applies to Redis, so this should be complete.
