### PR TITLE
Python 2.5 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Rdbtools is written in Python, though there are similar projects in other langua
 
 ## Installing rdbtools ##
 
-Pre-Requisites : 
+Pre-Requisites :
 
 1. python 2.x and pip.
 2. redis-py is optional and only needed to run test cases.
@@ -20,8 +20,8 @@ Pre-Requisites :
 To install from PyPI (recommended) :
 
     pip install rdbtools
-    
-To install from source : 
+
+To install from source :
 
     git clone https://github.com/sripathikrishnan/redis-rdb-tools
     cd redis-rdb-tools
@@ -32,12 +32,12 @@ To install from source :
 Parse the dump file and print the JSON on standard output
 
     rdb --command json /var/redis/6379/dump.rdb
-    
+
 Only process keys that match the regex
 
     rdb --command json --key "user.*" /var/redis/6379/dump.rdb
-    
-Only process hashes starting with "a", in database 2 
+
+Only process hashes starting with "a", in database 2
 
     rdb --command json --db 2 --type hash --key "a.*" /var/redis/6379/dump.rdb
 
@@ -49,14 +49,14 @@ Running with the  `-c memory` generates a CSV report with the approximate memory
     rdb -c memory /var/redis/6379/dump.rdb > memory.csv
 
 
-The generated CSV has the following columns - Database Number, Data Type, Key, Memory Used in bytes and Encoding. 
+The generated CSV has the following columns - Database Number, Data Type, Key, Memory Used in bytes and Encoding.
 Memory usage includes the key, the value and any other overheads.
 
 Note that the memory usage is approximate. In general, the actual memory used will be slightly higher than what is reported.
 
 You can filter the report on keys or database number or data type.
 
-The memory report should help you detect memory leaks caused by your application logic. It will also help you optimize Redis memory usage. 
+The memory report should help you detect memory leaks caused by your application logic. It will also help you optimize Redis memory usage.
 
 ## Find Memory used by a Single Key ##
 
@@ -67,9 +67,9 @@ In such cases, you can use the `redis-memory-for-key` command
 Example :
 
     redis-memory-for-key person:1
-    
+
     redis-memory-for-key -s localhost -p 6379 -a mypassword person:1
-    
+
 Output :
 
     Key 			"person:1"
@@ -79,7 +79,7 @@ Output :
     Number of Elements		2
     Length of Largest Element	8
 
-NOTE : 
+NOTE :
 
 1. This was added to redis-rdb-tools version 0.1.3
 2. This command depends [redis-py](https://github.com/andymccurdy/redis-py) package
@@ -90,7 +90,7 @@ First, use the --command diff option, and pipe the output to standard sort utili
 
     rdb --command diff /var/redis/6379/dump1.rdb | sort > dump1.txt
     rdb --command diff /var/redis/6379/dump2.rdb | sort > dump2.txt
-    
+
 Then, run your favourite diff program
 
     kdiff3 dump1.txt dump2.txt
@@ -103,22 +103,22 @@ To limit the size of the files, you can filter on keys using the --key=regex opt
     from rdbtools import RdbParser, RdbCallback
 
     class MyCallback(RdbCallback) :
-        ''' Simple example to show how callback works. 
+        ''' Simple example to show how callback works.
             See RdbCallback for all available callback methods.
             See JsonCallback for a concrete example
-        ''' 
+        '''
         def set(self, key, value, expiry):
             print('%s = %s' % (str(key), str(value)))
-        
+
         def hset(self, key, field, value):
             print('%s.%s = %s' % (str(key), str(field), str(value)))
-        
+
         def sadd(self, key, member):
             print('%s has {%s}' % (str(key), str(member)))
-        
+
         def rpush(self, key, value) :
             print('%s has [%s]' % (str(key), str(value)))
-        
+
         def zadd(self, key, score, member):
             print('%s has {%s : %s}' % (str(key), str(member), str(score)))
 
@@ -136,7 +136,7 @@ To limit the size of the files, you can filter on keys using the --key=regex opt
 
 rdbtools is licensed under the MIT License. See [LICENSE](https://github.com/sripathikrishnan/redis-rdb-tools/blob/master/LICENSE)
 
-## Maintained By 
+## Maintained By
 
 Sripathi Krishnan : @srithedabbler
 

--- a/rdbtools/cli/rdb.py
+++ b/rdbtools/cli/rdb.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import with_statement
 import os
 import sys
 from optparse import OptionParser
@@ -13,7 +14,7 @@ Example : %prog --command json -k "user.*" /var/redis/6379/dump.rdb"""
     parser = OptionParser(usage=usage)
     parser.add_option("-c", "--command", dest="command",
                   help="Command to execute. Valid commands are json or diff", metavar="FILE")
-                  
+
     parser.add_option("-f", "--file", dest="output",
                   help="Output file", metavar="FILE")
     parser.add_option("-n", "--db", dest="dbs", action="append",
@@ -21,15 +22,15 @@ Example : %prog --command json -k "user.*" /var/redis/6379/dump.rdb"""
     parser.add_option("-k", "--key", dest="keys", default=None,
                   help="Keys to export. This can be a regular expression")
     parser.add_option("-t", "--type", dest="types", action="append",
-                  help="""Data types to include. Possible values are string, hash, set, sortedset, list. Multiple typees can be provided. 
+                  help="""Data types to include. Possible values are string, hash, set, sortedset, list. Multiple typees can be provided.
                     If not specified, all data types will be returned""")
-    
+
     (options, args) = parser.parse_args()
-    
+
     if len(args) == 0:
         parser.error("Redis RDB file not specified")
     dump_file = args[0]
-    
+
     filters = {}
     if options.dbs:
         filters['dbs'] = []
@@ -38,10 +39,10 @@ Example : %prog --command json -k "user.*" /var/redis/6379/dump.rdb"""
                 filters['dbs'].append(int(x))
             except ValueError:
                 raise Exception('Invalid database number %s' %x)
-    
+
     if options.keys:
         filters['keys'] = options.keys
-    
+
     if options.types:
         filters['types'] = []
         for x in options.types:
@@ -49,7 +50,7 @@ Example : %prog --command json -k "user.*" /var/redis/6379/dump.rdb"""
                 raise Exception('Invalid type provided - %s. Expected one of %s' % (x, (", ".join(VALID_TYPES))))
             else:
                 filters['types'].append(x)
-    
+
     # TODO : Fix this ugly if-else code
     if options.output:
         with open(options.output, "wb") as f:
@@ -77,7 +78,7 @@ Example : %prog --command json -k "user.*" /var/redis/6379/dump.rdb"""
 
         parser = RdbParser(callback, filters=filters)
         parser.parse(dump_file)
-    
+
 if __name__ == '__main__':
     main()
 

--- a/rdbtools/cli/redis_memory_for_key.py
+++ b/rdbtools/cli/redis_memory_for_key.py
@@ -7,7 +7,7 @@ try :
     from StringIO import StringIO
 except ImportError:
     from io import StringIO
-    
+
 from optparse import OptionParser
 from rdbtools import RdbParser, JSONCallback, MemoryCallback
 from rdbtools.callbacks import encode_key
@@ -23,21 +23,21 @@ Examples :
 """
 
     parser = OptionParser(usage=usage)
-    parser.add_option("-s", "--server", dest="host", default="127.0.0.1", 
+    parser.add_option("-s", "--server", dest="host", default="127.0.0.1",
                   help="Redis Server hostname. Defaults to 127.0.0.1")
-    parser.add_option("-p", "--port", dest="port", default=6379, type="int", 
+    parser.add_option("-p", "--port", dest="port", default=6379, type="int",
                   help="Redis Server port. Defaults to 6379")
-    parser.add_option("-a", "--password", dest="password", 
+    parser.add_option("-a", "--password", dest="password",
                   help="Password to use when connecting to the server")
     parser.add_option("-d", "--db", dest="db", default=0,
                   help="Database number, defaults to 0")
-    
+
     (options, args) = parser.parse_args()
-    
+
     if len(args) == 0:
         parser.error("Key not specified")
     redis_key = args[0]
-    print_memory_for_key(redis_key, host=options.host, port=options.port, 
+    print_memory_for_key(redis_key, host=options.host, port=options.port,
                     db=options.db, password=options.password)
 
 def print_memory_for_key(key, host='localhost', port=6379, db=0, password=None):
@@ -51,7 +51,7 @@ def print_memory_for_key(key, host='localhost', port=6379, db=0, password=None):
     if not raw_dump:
         sys.stderr.write('Key %s does not exist\n' % key)
         sys.exit(-1)
-    
+
     stream = StringIO(raw_dump)
     data_type = read_unsigned_char(stream)
     parser.read_object(stream, data_type)
@@ -62,19 +62,19 @@ def connect_to_redis(host, port, db, password):
         if not check_redis_version(redis):
             sys.stderr.write('This script only works with Redis Server version 2.6.x or higher\n')
             sys.exit(-1)
-    except ConnectionError as e:
+    except ConnectionError, e:
         sys.stderr.write('Could not connect to Redis Server : %s\n' % e)
         sys.exit(-1)
-    except ResponseError as e:
+    except ResponseError, e:
         sys.stderr.write('Could not connect to Redis Server : %s\n' % e)
         sys.exit(-1)
     return redis
-    
+
 def check_redis_version(redis):
     server_info = redis.info()
     version_str = server_info['redis_version']
     version = tuple(map(int, version_str.split('.')))
-    
+
     if version[0] > 2 or (version[0] == 2 and version[1] >= 6) :
         return True
     else:
@@ -92,8 +92,8 @@ class PrintMemoryUsage():
             print("%s\t\t\t%s" % ("Encoding", record.encoding))
             print("%s\t\t%s" % ("Number of Elements", record.size))
             print("%s\t%s" % ("Length of Largest Element", record.len_largest_element))
-        
-        #print("%d,%s,%s,%d,%s,%d,%d\n" % (record.database, record.type, encode_key(record.key), 
+
+        #print("%d,%s,%s,%d,%s,%d,%d\n" % (record.database, record.type, encode_key(record.key),
         #                                         record.bytes, record.encoding, record.size, record.len_largest_element))
 
 if __name__ == '__main__':

--- a/rdbtools/memprofiler.py
+++ b/rdbtools/memprofiler.py
@@ -1,4 +1,8 @@
-from collections import namedtuple
+try:
+    from collections import namedtuple
+except ImportError:
+    from rdbtools.utils import namedtuple
+
 import random
 import json
 
@@ -21,13 +25,13 @@ class StatsAggregator():
         self.add_aggregate('database_memory', record.database, record.bytes)
         self.add_aggregate('type_memory', record.type, record.bytes)
         self.add_aggregate('encoding_memory', record.encoding, record.bytes)
-        
+
         self.add_aggregate('type_count', record.type, 1)
         self.add_aggregate('encoding_count', record.encoding, 1)
-    
+
         self.add_histogram(record.type + "_length", record.size)
         self.add_histogram(record.type + "_memory", (record.bytes/10) * 10)
-        
+
         if record.type == 'list':
             self.add_scatter('list_memory_by_length', record.bytes, record.size)
         elif record.type == 'hash':
@@ -44,12 +48,12 @@ class StatsAggregator():
     def add_aggregate(self, heading, subheading, metric):
         if not heading in self.aggregates :
             self.aggregates[heading] = {}
-        
+
         if not subheading in self.aggregates[heading]:
             self.aggregates[heading][subheading] = 0
-            
+
         self.aggregates[heading][subheading] += metric
-    
+
     def add_histogram(self, heading, metric):
         if not heading in self.histograms:
             self.histograms[heading] = {}
@@ -58,25 +62,25 @@ class StatsAggregator():
             self.histograms[heading][metric] = 1
         else :
             self.histograms[heading][metric] += 1
-    
+
     def add_scatter(self, heading, x, y):
         if not heading in self.scatters:
             self.scatters[heading] = []
         self.scatters[heading].append([x, y])
-  
+
     def get_json(self):
         return json.dumps({"aggregates":self.aggregates, "scatters":self.scatters, "histograms":self.histograms})
-        
+
 class PrintAllKeys():
     def __init__(self, out):
         self._out = out
-        self._out.write("%s,%s,%s,%s,%s,%s,%s\n" % ("database", "type", "key", 
+        self._out.write("%s,%s,%s,%s,%s,%s,%s\n" % ("database", "type", "key",
                                                  "size_in_bytes", "encoding", "num_elements", "len_largest_element"))
-    
+
     def next_record(self, record) :
-        self._out.write("%d,%s,%s,%d,%s,%d,%d\n" % (record.database, record.type, encode_key(record.key), 
+        self._out.write("%d,%s,%s,%d,%s,%d,%d\n" % (record.database, record.type, encode_key(record.key),
                                                  record.bytes, record.encoding, record.size, record.len_largest_element))
-    
+
 class MemoryCallback(RdbCallback):
     '''Calculates the memory used if this rdb file were loaded into RAM
         The memory usage is approximate, and based on heuristics.
@@ -88,12 +92,12 @@ class MemoryCallback(RdbCallback):
         self._current_encoding = None
         self._current_length = 0
         self._len_largest_element = 0
-        
+
         if architecture == 64 or architecture == '64':
             self._pointer_size = 8
         elif architecture == 32 or architecture == '32':
             self._pointer_size = 4
-        
+
     def start_rdb(self):
         pass
 
@@ -102,29 +106,29 @@ class MemoryCallback(RdbCallback):
 
     def end_database(self, db_number):
         pass
-        
+
     def end_rdb(self):
         pass
-       
+
     def set(self, key, value, expiry, info):
         self._current_encoding = info['encoding']
         size = self.sizeof_string(key) + self.sizeof_string(value) + self.top_level_object_overhead()
         size += 2*self.robj_overhead()
         size += self.key_expiry_overhead(expiry)
-        
+
         length = element_length(value)
         record = MemoryRecord(self._dbnum, "string", key, size, self._current_encoding, length, length)
         self._stream.next_record(record)
         self.end_key()
-    
+
     def start_hash(self, key, length, expiry, info):
         self._current_encoding = info['encoding']
-        self._current_length = length        
+        self._current_length = length
         size = self.sizeof_string(key)
         size += 2*self.robj_overhead()
         size += self.top_level_object_overhead()
         size += self.key_expiry_overhead(expiry)
-        
+
         if 'sizeof_value' in info:
             size += info['sizeof_value']
         elif 'encoding' in info and info['encoding'] == 'hashtable':
@@ -132,24 +136,24 @@ class MemoryCallback(RdbCallback):
         else:
             raise Exception('start_hash', 'Could not find encoding or sizeof_value in info object %s' % info)
         self._current_size = size
-    
+
     def hset(self, key, field, value):
         if(element_length(field) > self._len_largest_element) :
             self._len_largest_element = element_length(field)
         if(element_length(value) > self._len_largest_element) :
             self._len_largest_element = element_length(value)
-        
+
         if self._current_encoding == 'hashtable':
             self._current_size += self.sizeof_string(field)
             self._current_size += self.sizeof_string(value)
             self._current_size += self.hashtable_entry_overhead()
             self._current_size += 2*self.robj_overhead()
-    
+
     def end_hash(self, key):
         record = MemoryRecord(self._dbnum, "hash", key, self._current_size, self._current_encoding, self._current_length, self._len_largest_element)
         self._stream.next_record(record)
         self.end_key()
-    
+
     def start_set(self, key, cardinality, expiry, info):
         # A set is exactly like a hashmap
         self.start_hash(key, cardinality, expiry, info)
@@ -157,17 +161,17 @@ class MemoryCallback(RdbCallback):
     def sadd(self, key, member):
         if(element_length(member) > self._len_largest_element) :
             self._len_largest_element = element_length(member)
-            
+
         if self._current_encoding == 'hashtable':
             self._current_size += self.sizeof_string(member)
             self._current_size += self.hashtable_entry_overhead()
             self._current_size += self.robj_overhead()
-    
+
     def end_set(self, key):
         record = MemoryRecord(self._dbnum, "set", key, self._current_size, self._current_encoding, self._current_length, self._len_largest_element)
         self._stream.next_record(record)
         self.end_key()
-    
+
     def start_list(self, key, length, expiry, info):
         self._current_length = length
         self._current_encoding = info['encoding']
@@ -175,7 +179,7 @@ class MemoryCallback(RdbCallback):
         size += 2*self.robj_overhead()
         size += self.top_level_object_overhead()
         size += self.key_expiry_overhead(expiry)
-        
+
         if 'sizeof_value' in info:
             size += info['sizeof_value']
         elif 'encoding' in info and info['encoding'] == 'linkedlist':
@@ -183,21 +187,21 @@ class MemoryCallback(RdbCallback):
         else:
             raise Exception('start_list', 'Could not find encoding or sizeof_value in info object %s' % info)
         self._current_size = size
-            
+
     def rpush(self, key, value) :
         if(element_length(value) > self._len_largest_element) :
             self._len_largest_element = element_length(value)
-        
+
         if self._current_encoding == 'linkedlist':
             self._current_size += self.sizeof_string(value)
             self._current_size += self.linkedlist_entry_overhead()
             self._current_size += self.robj_overhead()
-    
+
     def end_list(self, key):
         record = MemoryRecord(self._dbnum, "list", key, self._current_size, self._current_encoding, self._current_length, self._len_largest_element)
         self._stream.next_record(record)
         self.end_key()
-    
+
     def start_sorted_set(self, key, length, expiry, info):
         self._current_length = length
         self._current_encoding = info['encoding']
@@ -205,7 +209,7 @@ class MemoryCallback(RdbCallback):
         size += 2*self.robj_overhead()
         size += self.top_level_object_overhead()
         size += self.key_expiry_overhead(expiry)
-        
+
         if 'sizeof_value' in info:
             size += info['sizeof_value']
         elif 'encoding' in info and info['encoding'] == 'skiplist':
@@ -213,27 +217,27 @@ class MemoryCallback(RdbCallback):
         else:
             raise Exception('start_sorted_set', 'Could not find encoding or sizeof_value in info object %s' % info)
         self._current_size = size
-    
+
     def zadd(self, key, score, member):
         if(element_length(member) > self._len_largest_element):
             self._len_largest_element = element_length(member)
-        
+
         if self._current_encoding == 'skiplist':
             self._current_size += 8 # self.sizeof_string(score)
             self._current_size += self.sizeof_string(member)
             self._current_size += 2*self.robj_overhead()
             self._current_size += self.skiplist_entry_overhead()
-    
+
     def end_sorted_set(self, key):
         record = MemoryRecord(self._dbnum, "sortedset", key, self._current_size, self._current_encoding, self._current_length, self._len_largest_element)
         self._stream.next_record(record)
         self.end_key()
-        
+
     def end_key(self):
         self._current_encoding = None
         self._current_size = 0
         self._len_largest_element = 0
-    
+
     def sizeof_string(self, string):
         # See struct sdshdr over here https://github.com/antirez/redis/blob/unstable/src/sds.h
         # int len :  4 bytes
@@ -253,7 +257,7 @@ class MemoryCallback(RdbCallback):
         return len(string) + 8 + 1 + self.malloc_overhead()
 
     def top_level_object_overhead(self):
-        # Each top level object is an entry in a dictionary, and so we have to include 
+        # Each top level object is an entry in a dictionary, and so we have to include
         # the overhead of a dictionary entry
         return self.hashtable_entry_overhead()
 
@@ -264,70 +268,70 @@ class MemoryCallback(RdbCallback):
         # Key expiry is stored in a hashtable, so we have to pay for the cost of a hashtable entry
         # The timestamp itself is stored as an int64, which is a 8 bytes
         return self.hashtable_entry_overhead() + 8
-        
+
     def hashtable_overhead(self, size):
         # See  https://github.com/antirez/redis/blob/unstable/src/dict.h
         # See the structures dict and dictht
         # 2 * (3 unsigned longs + 1 pointer) + 2 ints + 2 pointers
         #   = 56 + 4 * sizeof_pointer()
-        # 
+        #
         # Additionally, see **table in dictht
         # The length of the table is the next power of 2
         # When the hashtable is rehashing, another instance of **table is created
-        # We are assuming 0.5 percent probability of rehashing, and so multiply 
+        # We are assuming 0.5 percent probability of rehashing, and so multiply
         # the size of **table by 1.5
         return 56 + 4*self.sizeof_pointer() + self.next_power(size)*self.sizeof_pointer()*1.5
-        
+
     def hashtable_entry_overhead(self):
         # See  https://github.com/antirez/redis/blob/unstable/src/dict.h
-        # Each dictEntry has 3 pointers 
+        # Each dictEntry has 3 pointers
         return 3*self.sizeof_pointer()
-    
+
     def linkedlist_overhead(self):
         # See https://github.com/antirez/redis/blob/unstable/src/adlist.h
         # A list has 5 pointers + an unsigned long
         return 8 + 5*self.sizeof_pointer()
-    
+
     def linkedlist_entry_overhead(self):
         # See https://github.com/antirez/redis/blob/unstable/src/adlist.h
         # A node has 3 pointers
         return 3*self.sizeof_pointer()
-    
+
     def skiplist_overhead(self, size):
         return 2*self.sizeof_pointer() + self.hashtable_overhead(size) + (2*self.sizeof_pointer() + 16)
-    
+
     def skiplist_entry_overhead(self):
         return self.hashtable_entry_overhead() + 2*self.sizeof_pointer() + 8 + (self.sizeof_pointer() + 8) * self.zset_random_level()
-    
+
     def robj_overhead(self):
         return self.sizeof_pointer() + 8
-        
+
     def malloc_overhead(self):
         return self.size_t()
 
     def size_t(self):
         return self.sizeof_pointer()
-        
+
     def sizeof_pointer(self):
         return self._pointer_size
-        
+
     def next_power(self, size):
         power = 1
         while (power <= size) :
             power = power << 1
         return power
- 
+
     def zset_random_level(self):
         level = 1
         rint = random.randint(0, 0xFFFF)
         while (rint < ZSKIPLIST_P * 0xFFFF):
             level += 1
-            rint = random.randint(0, 0xFFFF)        
+            rint = random.randint(0, 0xFFFF)
         if level < ZSKIPLIST_MAXLEVEL :
             return level
         else:
             return ZSKIPLIST_MAXLEVEL
-        
+
 
 def element_length(element):
     if isinstance(element, int):
@@ -336,4 +340,4 @@ def element_length(element):
         return 16
     else:
         return len(element)
-    
+

--- a/rdbtools/memprofiler.py
+++ b/rdbtools/memprofiler.py
@@ -1,7 +1,7 @@
 try:
     from collections import namedtuple
 except ImportError:
-    from utils.namedtuple import namedtuple
+    from rdbtools.utils.namedtuple import namedtuple
 
 import random
 try:

--- a/rdbtools/memprofiler.py
+++ b/rdbtools/memprofiler.py
@@ -1,7 +1,7 @@
 try:
     from collections import namedtuple
 except ImportError:
-    from rdbtools.utils.namedtuple import namedtuple
+    from utils.namedtuple import namedtuple
 
 import random
 try:

--- a/rdbtools/memprofiler.py
+++ b/rdbtools/memprofiler.py
@@ -4,7 +4,10 @@ except ImportError:
     from rdbtools.utils import namedtuple
 
 import random
-import json
+try:
+    import json
+except ImportError:
+    import simplejson as json
 
 from rdbtools.parser import RdbCallback
 from rdbtools.callbacks import encode_key

--- a/rdbtools/memprofiler.py
+++ b/rdbtools/memprofiler.py
@@ -1,7 +1,7 @@
 try:
     from collections import namedtuple
 except ImportError:
-    from rdbtools.utils import namedtuple
+    from rdbtools.utils.namedtuple import namedtuple
 
 import random
 try:

--- a/rdbtools/parser.py
+++ b/rdbtools/parser.py
@@ -1,3 +1,4 @@
+from __future__ import with_statement
 import struct
 import io
 import sys
@@ -8,7 +9,7 @@ try :
     from StringIO import StringIO
 except ImportError:
     from io import StringIO
-    
+
 REDIS_RDB_6BITLEN = 0
 REDIS_RDB_14BITLEN = 1
 REDIS_RDB_32BITLEN = 2
@@ -36,202 +37,202 @@ REDIS_RDB_ENC_INT32 = 2
 REDIS_RDB_ENC_LZF = 3
 
 DATA_TYPE_MAPPING = {
-    0 : "string", 1 : "list", 2 : "set", 3 : "sortedset", 4 : "hash", 
+    0 : "string", 1 : "list", 2 : "set", 3 : "sortedset", 4 : "hash",
     9 : "hash", 10 : "list", 11 : "set", 12 : "sortedset", 13 : "hash"}
 
 class RdbCallback:
     """
     A Callback to handle events as the Redis dump file is parsed.
     This callback provides a serial and fast access to the dump file.
-    
+
     """
     def start_rdb(self):
         """
         Called once we know we are dealing with a valid redis dump file
-        
+
         """
         pass
-        
+
     def start_database(self, db_number):
         """
-        Called to indicate database the start of database `db_number` 
-        
-        Once a database starts, another database cannot start unless 
+        Called to indicate database the start of database `db_number`
+
+        Once a database starts, another database cannot start unless
         the first one completes and then `end_database` method is called
-        
+
         Typically, callbacks store the current database number in a class variable
-        
-        """     
+
+        """
         pass
-    
+
     def set(self, key, value, expiry, info):
         """
         Callback to handle a key with a string value and an optional expiry
-        
+
         `key` is the redis key
         `value` is a string or a number
         `expiry` is a datetime object. None and can be None
         `info` is a dictionary containing additional information about this object.
-        
+
         """
         pass
-    
+
     def start_hash(self, key, length, expiry, info):
         """Callback to handle the start of a hash
-        
+
         `key` is the redis key
-        `length` is the number of elements in this hash. 
+        `length` is the number of elements in this hash.
         `expiry` is a `datetime` object. None means the object does not expire
         `info` is a dictionary containing additional information about this object.
-        
+
         After `start_hash`, the method `hset` will be called with this `key` exactly `length` times.
         After that, the `end_hash` method will be called.
-        
+
         """
         pass
-    
+
     def hset(self, key, field, value):
         """
         Callback to insert a field=value pair in an existing hash
-        
+
         `key` is the redis key for this hash
         `field` is a string
         `value` is the value to store for this field
-        
+
         """
         pass
-    
+
     def end_hash(self, key):
         """
         Called when there are no more elements in the hash
-        
+
         `key` is the redis key for the hash
-        
+
         """
         pass
-    
+
     def start_set(self, key, cardinality, expiry, info):
         """
         Callback to handle the start of a hash
-        
+
         `key` is the redis key
         `cardinality` is the number of elements in this set
         `expiry` is a `datetime` object. None means the object does not expire
         `info` is a dictionary containing additional information about this object.
-        
+
         After `start_set`, the  method `sadd` will be called with `key` exactly `cardinality` times
         After that, the `end_set` method will be called to indicate the end of the set.
-        
+
         Note : This callback handles both Int Sets and Regular Sets
-        
+
         """
         pass
 
     def sadd(self, key, member):
         """
         Callback to inser a new member to this set
-        
+
         `key` is the redis key for this set
         `member` is the member to insert into this set
-        
+
         """
         pass
-    
+
     def end_set(self, key):
         """
-        Called when there are no more elements in this set 
-        
+        Called when there are no more elements in this set
+
         `key` the redis key for this set
-        
+
         """
         pass
-    
+
     def start_list(self, key, length, expiry, info):
         """
         Callback to handle the start of a list
-        
+
         `key` is the redis key for this list
         `length` is the number of elements in this list
         `expiry` is a `datetime` object. None means the object does not expire
         `info` is a dictionary containing additional information about this object.
-        
+
         After `start_list`, the method `rpush` will be called with `key` exactly `length` times
         After that, the `end_list` method will be called to indicate the end of the list
-        
+
         Note : This callback handles both Zip Lists and Linked Lists.
-        
+
         """
         pass
-    
+
     def rpush(self, key, value) :
         """
         Callback to insert a new value into this list
-        
+
         `key` is the redis key for this list
         `value` is the value to be inserted
-        
+
         Elements must be inserted to the end (i.e. tail) of the existing list.
-        
+
         """
         pass
-    
+
     def end_list(self, key):
         """
         Called when there are no more elements in this list
-        
+
         `key` the redis key for this list
-        
+
         """
         pass
-    
+
     def start_sorted_set(self, key, length, expiry, info):
         """
         Callback to handle the start of a sorted set
-        
+
         `key` is the redis key for this sorted
         `length` is the number of elements in this sorted set
         `expiry` is a `datetime` object. None means the object does not expire
         `info` is a dictionary containing additional information about this object.
-        
-        After `start_sorted_set`, the method `zadd` will be called with `key` exactly `length` times. 
+
+        After `start_sorted_set`, the method `zadd` will be called with `key` exactly `length` times.
         Also, `zadd` will be called in a sorted order, so as to preserve the ordering of this sorted set.
         After that, the `end_sorted_set` method will be called to indicate the end of this sorted set
-        
+
         Note : This callback handles sorted sets in that are stored as ziplists or skiplists
-        
+
         """
         pass
-    
+
     def zadd(self, key, score, member):
         """Callback to insert a new value into this sorted set
-        
+
         `key` is the redis key for this sorted set
         `score` is the score for this `value`
         `value` is the element being inserted
         """
         pass
-    
+
     def end_sorted_set(self, key):
         """
         Called when there are no more elements in this sorted set
-        
+
         `key` is the redis key for this sorted set
-        
+
         """
         pass
-    
+
     def end_database(self, db_number):
         """
         Called when the current database ends
-        
-        After `end_database`, one of the methods are called - 
+
+        After `end_database`, one of the methods are called -
         1) `start_database` with a new database number
             OR
         2) `end_rdb` to indicate we have reached the end of the file
-        
+
         """
         pass
-    
+
     def end_rdb(self):
         """Called to indicate we have completed parsing of the dump file"""
         pass
@@ -239,19 +240,19 @@ class RdbCallback:
 class RdbParser :
     """
     A Parser for Redis RDB Files
-    
+
     This class is similar in spirit to a SAX parser for XML files.
     The dump file is parsed sequentially. As and when objects are discovered,
-    appropriate methods in the callback are called. 
-        
+    appropriate methods in the callback are called.
+
     Typical usage :
         callback = MyRdbCallback() # Typically a subclass of RdbCallback
         parser = RdbParser(callback)
         parser.parse('/var/redis/6379/dump.rdb')
-    
+
     filter is a dictionary with the following keys
         {"dbs" : [0, 1], "keys" : "foo.*", "types" : ["hash", "set", "sortedset", "list", "string"]}
-        
+
         If filter is None, results will not be filtered
         If dbs, keys or types is None or Empty, no filtering will be done on that axis
     """
@@ -266,27 +267,27 @@ class RdbParser :
 
     def parse(self, filename):
         """
-        Parse a redis rdb dump file, and call methods in the 
+        Parse a redis rdb dump file, and call methods in the
         callback object during the parsing operation.
         """
         with open(filename, "rb") as f:
             self.verify_magic_string(f.read(5))
             self.verify_version(f.read(4))
             self._callback.start_rdb()
-            
+
             is_first_database = True
             db_number = 0
             while True :
                 self._expiry = None
                 data_type = read_unsigned_char(f)
-                
+
                 if data_type == REDIS_RDB_OPCODE_EXPIRETIME_MS :
                     self._expiry = to_datetime(read_unsigned_long(f) * 1000)
                     data_type = read_unsigned_char(f)
                 elif data_type == REDIS_RDB_OPCODE_EXPIRETIME :
                     self._expiry = to_datetime(read_unsigned_int(f) * 1000000)
                     data_type = read_unsigned_char(f)
-                
+
                 if data_type == REDIS_RDB_OPCODE_SELECTDB :
                     if not is_first_database :
                         self._callback.end_database(db_number)
@@ -294,7 +295,7 @@ class RdbParser :
                     db_number = self.read_length(f)
                     self._callback.start_database(db_number)
                     continue
-                
+
                 if data_type == REDIS_RDB_OPCODE_EOF :
                     self._callback.end_database(db_number)
                     self._callback.end_rdb()
@@ -351,7 +352,7 @@ class RdbParser :
         return val
 
     # Read an object for the stream
-    # f is the redis file 
+    # f is the redis file
     # enc_type is the type of object
     def read_object(self, f, enc_type) :
         if enc_type == REDIS_RDB_TYPE_STRING :
@@ -360,7 +361,7 @@ class RdbParser :
         elif enc_type == REDIS_RDB_TYPE_LIST :
             # A redis list is just a sequence of strings
             # We successively read strings from the stream and create a list from it
-            # The lists are in order i.e. the first string is the head, 
+            # The lists are in order i.e. the first string is the head,
             # and the last string is the tail of the list
             length = self.read_length(f)
             self._callback.start_list(self._key, length, self._expiry, info={'encoding':'linkedlist' })
@@ -432,7 +433,7 @@ class RdbParser :
                 bytes_to_skip = clen
         else :
             bytes_to_skip = length
-        
+
         skip(f, bytes_to_skip)
 
     def skip_object(self, f, enc_type):
@@ -492,7 +493,7 @@ class RdbParser :
             val = self.read_ziplist_entry(buff)
             self._callback.rpush(self._key, val)
         zlist_end = read_unsigned_char(buff)
-        if zlist_end != 255 : 
+        if zlist_end != 255 :
             raise Exception('read_ziplist', "Invalid zip list end - %d for key %s" % (zlist_end, self._key))
         self._callback.end_list(self._key)
 
@@ -513,7 +514,7 @@ class RdbParser :
                 score = float(score)
             self._callback.zadd(self._key, score, member)
         zlist_end = read_unsigned_char(buff)
-        if zlist_end != 255 : 
+        if zlist_end != 255 :
             raise Exception('read_zset_from_ziplist', "Invalid zip list end - %d for key %s" % (zlist_end, self._key))
         self._callback.end_sorted_set(self._key)
 
@@ -532,11 +533,11 @@ class RdbParser :
             value = self.read_ziplist_entry(buff)
             self._callback.hset(self._key, field, value)
         zlist_end = read_unsigned_char(buff)
-        if zlist_end != 255 : 
+        if zlist_end != 255 :
             raise Exception('read_hash_from_ziplist', "Invalid zip list end - %d for key %s" % (zlist_end, self._key))
         self._callback.end_hash(self._key)
-    
-    
+
+
     def read_ziplist_entry(self, f) :
         length = 0
         value = None
@@ -568,7 +569,7 @@ class RdbParser :
         else :
             raise Exception('read_ziplist_entry', 'Invalid entry_header %d for key %s' % (entry_header, self._key))
         return value
-        
+
     def read_zipmap(self, f) :
         raw_string = self.read_string(f)
         buff = io.BytesIO(bytearray(raw_string))
@@ -581,14 +582,14 @@ class RdbParser :
             key = buff.read(next_length)
             next_length = self.read_zipmap_next_length(buff)
             if next_length is None :
-                raise Exception('read_zip_map', 'Unexepcted end of zip map for key %s' % self._key)        
+                raise Exception('read_zip_map', 'Unexepcted end of zip map for key %s' % self._key)
             free = read_unsigned_char(buff)
             value = buff.read(next_length)
             try:
                 value = int(value)
             except ValueError:
                 pass
-            
+
             skip(buff, free)
             self._callback.hset(self._key, key, value)
         self._callback.end_hash(self._key)
@@ -608,7 +609,7 @@ class RdbParser :
 
     def verify_version(self, version_str) :
         version = int(version_str)
-        if version < 1 or version > 6 : 
+        if version < 1 or version > 6 :
             raise Exception('verify_version', 'Invalid RDB version number %d' % version)
 
     def init_filter(self, filters):
@@ -624,7 +625,7 @@ class RdbParser :
             self._filters['dbs'] = [int(x) for x in filters['dbs']]
         else:
             raise Exception('init_filter', 'invalid value for dbs in filter %s' %filters['dbs'])
-        
+
         if not ('keys' in filters and filters['keys']):
             self._filters['keys'] = re.compile(".*")
         else:
@@ -638,7 +639,7 @@ class RdbParser :
             self._filters['types'] = [str(x) for x in filters['types']]
         else:
             raise Exception('init_filter', 'invalid value for types in filter %s' %filters['types'])
-        
+
     def matches_filter(self, db_number, key=None, data_type=None):
         if self._filters['dbs'] and (not db_number in self._filters['dbs']):
             return False
@@ -648,17 +649,17 @@ class RdbParser :
         if data_type is not None and (not self.get_logical_type(data_type) in self._filters['types']):
             return False
         return True
-    
+
     def get_logical_type(self, data_type):
         return DATA_TYPE_MAPPING[data_type]
-        
+
     def lzf_decompress(self, compressed, expected_length):
         in_stream = bytearray(compressed)
         in_len = len(in_stream)
         in_index = 0
         out_stream = bytearray()
         out_index = 0
-    
+
         while in_index < in_len :
             ctrl = in_stream[in_index]
             if not isinstance(ctrl, int) :
@@ -675,7 +676,7 @@ class RdbParser :
                 if length == 7 :
                     length = length + in_stream[in_index]
                     in_index = in_index + 1
-                
+
                 ref = out_index - ((ctrl & 0x1f) << 8) - in_stream[in_index] - 1
                 in_index = in_index + 1
                 for x in xrange(0, length + 2) :
@@ -705,22 +706,22 @@ def to_datetime(usecs_since_epoch):
     dt = datetime.datetime.utcfromtimestamp(seconds_since_epoch)
     delta = datetime.timedelta(microseconds = useconds)
     return dt + delta
-    
+
 def read_signed_char(f) :
     return struct.unpack('b', f.read(1))[0]
-    
+
 def read_unsigned_char(f) :
     return struct.unpack('B', f.read(1))[0]
 
 def read_signed_short(f) :
     return struct.unpack('h', f.read(2))[0]
-        
+
 def read_unsigned_short(f) :
     return struct.unpack('H', f.read(2))[0]
 
 def read_signed_int(f) :
     return struct.unpack('i', f.read(4))[0]
-    
+
 def read_unsigned_int(f) :
     return struct.unpack('I', f.read(4))[0]
 
@@ -731,10 +732,10 @@ def read_24bit_signed_number(f):
     s = '0' + f.read(3)
     num = struct.unpack('i', s)[0]
     return num >> 8
-    
+
 def read_signed_long(f) :
     return struct.unpack('q', f.read(8))[0]
-    
+
 def read_unsigned_long(f) :
     return struct.unpack('Q', f.read(8))[0]
 
@@ -749,53 +750,53 @@ def string_as_hexcode(string) :
 class DebugCallback(RdbCallback) :
     def start_rdb(self):
         print('[')
-    
+
     def start_database(self, db_number):
         print('{')
-    
+
     def set(self, key, value, expiry):
         print('"%s" : "%s"' % (str(key), str(value)))
-    
+
     def start_hash(self, key, length, expiry):
         print('"%s" : {' % str(key))
         pass
-    
+
     def hset(self, key, field, value):
         print('"%s" : "%s"' % (str(field), str(value)))
-    
+
     def end_hash(self, key):
         print('}')
-    
+
     def start_set(self, key, cardinality, expiry):
         print('"%s" : [' % str(key))
 
     def sadd(self, key, member):
         print('"%s"' % str(member))
-    
+
     def end_set(self, key):
         print(']')
-    
+
     def start_list(self, key, length, expiry):
         print('"%s" : [' % str(key))
-    
+
     def rpush(self, key, value) :
         print('"%s"' % str(value))
-    
+
     def end_list(self, key):
         print(']')
-    
+
     def start_sorted_set(self, key, length, expiry):
         print('"%s" : {' % str(key))
-    
+
     def zadd(self, key, score, member):
         print('"%s" : "%s"' % (str(member), str(score)))
-    
+
     def end_sorted_set(self, key):
         print('}')
-    
+
     def end_database(self, db_number):
         print('}')
-    
+
     def end_rdb(self):
         print(']')
 

--- a/rdbtools/parser.py
+++ b/rdbtools/parser.py
@@ -661,10 +661,17 @@ class RdbParser :
         return DATA_TYPE_MAPPING[data_type]
 
     def lzf_decompress(self, compressed, expected_length):
-        in_stream = array.array('B', compressed)
+        bytearray_present = True
+        try:
+            in_stream = bytearray(compressed)
+            out_stream = bytearray()
+        except NameError:
+            in_stream = array.array('B', compressed)
+            out_stream = array.array('B')
+            bytearray_present = False
         in_len = len(in_stream)
         in_index = 0
-        out_stream = array.array('B')
+
         out_index = 0
 
         while in_index < in_len :
@@ -692,8 +699,10 @@ class RdbParser :
                     out_index = out_index + 1
         if len(out_stream) != expected_length :
             raise Exception('lzf_decompress', 'Expected lengths do not match %d != %d for key %s' % (len(out_stream), expected_length, self._key))
-        # return str(out_stream)
-        return out_stream.tostring()
+        if bytearray_present:
+            return str(out_stream)
+        else:
+            return out_stream.tostring()
 
 def skip(f, free):
     if free :

--- a/rdbtools/parser.py
+++ b/rdbtools/parser.py
@@ -578,8 +578,20 @@ class RdbParser :
 
     def read_zipmap(self, f) :
         raw_string = self.read_string(f)
-        raw_byte_arr = array.array('B', raw_string)
-        buff = io.BytesIO(raw_byte_arr.tostring())
+        bytearray_present = True
+        try:
+            raw_byte_arr = bytearray(raw_string)
+        except NameError:
+            raw_byte_arr = array.array('B', raw_string)
+            bytearray_present = False
+        if bytearray_present:
+            byte_str = str(raw_byte_arr)
+        else:
+            byte_str = raw_byte_arr.tostring()
+        try:
+            buff = io.BytesIO(byte_str)
+        except AttributeError:
+            buff = io.StringIO(byte_str)
         num_entries = read_unsigned_char(buff)
         self._callback.start_hash(self._key, num_entries, self._expiry, info={'encoding':'zipmap', 'sizeof_value':len(raw_string)})
         while True :

--- a/rdbtools/parser.py
+++ b/rdbtools/parser.py
@@ -578,7 +578,6 @@ class RdbParser :
 
     def read_zipmap(self, f) :
         raw_string = self.read_string(f)
-        # raw_byte_arr = bytearray(raw_string)
         raw_byte_arr = array.array('B', raw_string)
         buff = io.BytesIO(raw_byte_arr.tostring())
         num_entries = read_unsigned_char(buff)

--- a/rdbtools/parser.py
+++ b/rdbtools/parser.py
@@ -1,6 +1,10 @@
 from __future__ import with_statement
 import struct
-import io
+try:
+    import io
+except ImportError:
+    import StringIO as io
+
 import sys
 import datetime
 import re

--- a/rdbtools/utils/namedtuple.py
+++ b/rdbtools/utils/namedtuple.py
@@ -1,0 +1,147 @@
+from operator import itemgetter as _itemgetter
+from keyword import iskeyword as _iskeyword
+import sys as _sys
+
+def namedtuple(typename, field_names, verbose=False, rename=False):
+    """Returns a new subclass of tuple with named fields.
+
+    >>> Point = namedtuple('Point', 'x y')
+    >>> Point.__doc__                   # docstring for the new class
+    'Point(x, y)'
+    >>> p = Point(11, y=22)             # instantiate with positional args or keywords
+    >>> p[0] + p[1]                     # indexable like a plain tuple
+    33
+    >>> x, y = p                        # unpack like a regular tuple
+    >>> x, y
+    (11, 22)
+    >>> p.x + p.y                       # fields also accessable by name
+    33
+    >>> d = p._asdict()                 # convert to a dictionary
+    >>> d['x']
+    11
+    >>> Point(**d)                      # convert from a dictionary
+    Point(x=11, y=22)
+    >>> p._replace(x=100)               # _replace() is like str.replace() but targets named fields
+    Point(x=100, y=22)
+
+    """
+
+    # Parse and validate the field names.  Validation serves two purposes,
+    # generating informative error messages and preventing template injection attacks.
+    if isinstance(field_names, basestring):
+        field_names = field_names.replace(',', ' ').split() # names separated by whitespace and/or commas
+    field_names = tuple(map(str, field_names))
+    if rename:
+        names = list(field_names)
+        seen = set()
+        for i, name in enumerate(names):
+            if (not min(c.isalnum() or c=='_' for c in name) or _iskeyword(name)
+                or not name or name[0].isdigit() or name.startswith('_')
+                or name in seen):
+                    names[i] = '_%d' % i
+            seen.add(name)
+        field_names = tuple(names)
+    for name in (typename,) + field_names:
+        if not min(c.isalnum() or c=='_' for c in name):
+            raise ValueError('Type names and field names can only contain alphanumeric characters and underscores: %r' % name)
+        if _iskeyword(name):
+            raise ValueError('Type names and field names cannot be a keyword: %r' % name)
+        if name[0].isdigit():
+            raise ValueError('Type names and field names cannot start with a number: %r' % name)
+    seen_names = set()
+    for name in field_names:
+        if name.startswith('_') and not rename:
+            raise ValueError('Field names cannot start with an underscore: %r' % name)
+        if name in seen_names:
+            raise ValueError('Encountered duplicate field name: %r' % name)
+        seen_names.add(name)
+
+    # Create and fill-in the class template
+    numfields = len(field_names)
+    argtxt = repr(field_names).replace("'", "")[1:-1]   # tuple repr without parens or quotes
+    reprtxt = ', '.join('%s=%%r' % name for name in field_names)
+    template = '''class %(typename)s(tuple):
+        '%(typename)s(%(argtxt)s)' \n
+        __slots__ = () \n
+        _fields = %(field_names)r \n
+        def __new__(_cls, %(argtxt)s):
+            return _tuple.__new__(_cls, (%(argtxt)s)) \n
+        @classmethod
+        def _make(cls, iterable, new=tuple.__new__, len=len):
+            'Make a new %(typename)s object from a sequence or iterable'
+            result = new(cls, iterable)
+            if len(result) != %(numfields)d:
+                raise TypeError('Expected %(numfields)d arguments, got %%d' %% len(result))
+            return result \n
+        def __repr__(self):
+            return '%(typename)s(%(reprtxt)s)' %% self \n
+        def _asdict(self):
+            'Return a new dict which maps field names to their values'
+            return dict(zip(self._fields, self)) \n
+        def _replace(_self, **kwds):
+            'Return a new %(typename)s object replacing specified fields with new values'
+            result = _self._make(map(kwds.pop, %(field_names)r, _self))
+            if kwds:
+                raise ValueError('Got unexpected field names: %%r' %% kwds.keys())
+            return result \n
+        def __getnewargs__(self):
+            return tuple(self) \n\n''' % locals()
+    for i, name in enumerate(field_names):
+        template += '        %s = _property(_itemgetter(%d))\n' % (name, i)
+    if verbose:
+        print template
+
+    # Execute the template string in a temporary namespace
+    namespace = dict(_itemgetter=_itemgetter, __name__='namedtuple_%s' % typename,
+                     _property=property, _tuple=tuple)
+    try:
+        exec template in namespace
+    except SyntaxError, e:
+        raise SyntaxError(e.message + ':\n' + template)
+    result = namespace[typename]
+
+    # For pickling to work, the __module__ variable needs to be set to the frame
+    # where the named tuple is created.  Bypass this step in enviroments where
+    # sys._getframe is not defined (Jython for example) or sys._getframe is not
+    # defined for arguments greater than 0 (IronPython).
+    try:
+        result.__module__ = _sys._getframe(1).f_globals.get('__name__', '__main__')
+    except (AttributeError, ValueError):
+        pass
+
+    return result
+
+
+
+
+
+
+if __name__ == '__main__':
+    # verify that instances can be pickled
+    from cPickle import loads, dumps
+    Point = namedtuple('Point', 'x, y', True)
+    p = Point(x=10, y=20)
+    assert p == loads(dumps(p, -1))
+
+    # test and demonstrate ability to override methods
+    class Point(namedtuple('Point', 'x y')):
+        @property
+        def hypot(self):
+            return (self.x ** 2 + self.y ** 2) ** 0.5
+        def __str__(self):
+            return 'Point: x=%6.3f y=%6.3f hypot=%6.3f' % (self.x, self.y, self.hypot)
+
+    for p in Point(3,4), Point(14,5), Point(9./7,6):
+        print p
+
+    class Point(namedtuple('Point', 'x y')):
+        'Point class with optimized _make() and _replace() without error-checking'
+        _make = classmethod(tuple.__new__)
+        def _replace(self, _map=map, **kwds):
+            return self._make(_map(kwds.get, ('x', 'y'), self))
+
+    print Point(11, 22)._replace(x=100)
+
+    import doctest
+    TestResults = namedtuple('TestResults', 'failed attempted')
+    print TestResults(*doctest.testmod())

--- a/rdbtools/utils/namedtuple.py
+++ b/rdbtools/utils/namedtuple.py
@@ -112,10 +112,6 @@ def namedtuple(typename, field_names, verbose=False, rename=False):
     return result
 
 
-
-
-
-
 if __name__ == '__main__':
     # verify that instances can be pickled
     from cPickle import loads, dumps

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 redis==2.4.12
 wsgiref==0.1.2
+simplejson==2.0.6

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ sdict = {
     'maintainer_email' : 'Sripathi.Krishnan@gmail.com',
     'keywords' : ['Redis', 'RDB', 'Export', 'Dump', 'Memory Profiler'],
     'license' : 'MIT',
-    'packages' : ['rdbtools', 'rdbtools.cli'],
+    'packages' : ['rdbtools', 'rdbtools.cli', 'rdbtools.utils'],
     'package_data' : {'rdbtools.cli': ['*.template']},
     'test_suite' : 'tests.all_tests',
     'entry_points' : {


### PR DESCRIPTION
Some of our servers are still on Python 2.5 and I wanted to get a profile of Redis on these servers using this tool. Here are some of the changes I made:
- If the `io` module isn't present, use `StringIO`
- If the `json` modulle isn't present, use `simplejson`
- Install `simplejson` as a prerequisite in `requirements.txt`
- Added a `utils` directory with a `namedtuple` implementation
- Used `array` from the `array` module with a type of `unsigned char` if the `bytearray` type isn't available.
- Used `StringIO` from the `StringIO` module if `BytesIO` from the `io` module isn't available

All tests pass on Python 2.5, 2.6 and 2.7.

I completely understand if you don't wish to pull in these changes, given that Python 2.5 support is extra work, I'm just happy to contribute in any way I can.

Thanks,
-Mark
