### PR TITLE
Option to emit Redis protocol from rdb command

### DIFF
--- a/rdbtools/__init__.py
+++ b/rdbtools/__init__.py
@@ -1,10 +1,10 @@
 from rdbtools.parser import RdbCallback, RdbParser, DebugCallback
-from rdbtools.callbacks import JSONCallback, DiffCallback
+from rdbtools.callbacks import JSONCallback, DiffCallback, ProtocolCallback
 from rdbtools.memprofiler import MemoryCallback, PrintAllKeys, StatsAggregator
 
 __version__ = '0.1.5'
 VERSION = tuple(map(int, __version__.split('.')))
 
 __all__ = [
-    'RdbParser', 'RdbCallback', 'JSONCallback', 'DiffCallback, MemoryCallback', 'PrintAllKeys']
+    'RdbParser', 'RdbCallback', 'JSONCallback', 'DiffCallback', 'MemoryCallback', 'ProtocolCallback', 'PrintAllKeys']
 

--- a/rdbtools/callbacks.py
+++ b/rdbtools/callbacks.py
@@ -1,3 +1,4 @@
+import calendar
 import re
 from decimal import Decimal
 import sys
@@ -91,6 +92,7 @@ def encode_key(s):
 
 def encode_value(s):
     return _encode(s, quote_numbers=False)
+
 
 class JSONCallback(RdbCallback):
     def __init__(self, out):
@@ -258,3 +260,103 @@ class DiffCallback(RdbCallback):
     def newline(self):
         self._out.write('\r\n')
 
+
+def _unix_timestamp(dt):
+     return calendar.timegm(dt.utctimetuple())
+
+
+class ProtocolCallback(RdbCallback):
+    def __init__(self, out):
+        self._out = out
+        self.reset()
+
+    def reset(self):
+        self._expires = {}
+
+    def set_expiry(self, key, dt):
+        self._expires[key] = dt
+
+    def get_expiry_seconds(self, key):
+        if key in self._expires:
+            return _unix_timestamp(self._expires[key])
+        return None
+
+    def expires(self, key):
+        return key in self._expires
+
+    def pre_expiry(self, key, expiry):
+        if expiry is not None:
+            self.set_expiry(key, expiry)
+
+    def post_expiry(self, key):
+        if self.expires(key):
+            self.expireat(key, self.get_expiry_seconds(key))
+
+    def emit(self, *args):
+        self._out.write(u"*" + unicode(len(args)) + u"\r\n")
+        for arg in args:
+            self._out.write(u"$" + unicode(len(unicode(arg))) + u"\r\n")
+            self._out.write(unicode(arg) + u"\r\n")
+
+    def start_database(self, db_number):
+        self.reset()
+        self.select(db_number)
+
+    # String handling
+
+    def set(self, key, value, expiry, info):
+        self.pre_expiry(key, expiry)
+        self.emit('SET', key, value)
+        self.post_expiry(key)
+
+    # Hash handling
+
+    def start_hash(self, key, length, expiry, info):
+        self.pre_expiry(key, expiry)
+
+    def hset(self, key, field, value):
+        self.emit('HSET', key, field, value)
+
+    def end_hash(self, key):
+        self.post_expiry(key)
+
+    # Set handling
+
+    def start_set(self, key, cardinality, expiry, info):
+        self.pre_expiry(key, expiry)
+
+    def sadd(self, key, member):
+        self.emit('SADD', key, member)
+
+    def end_set(self, key):
+        self.post_expiry(key)
+
+    # List handling
+
+    def start_list(self, key, length, expiry, info):
+        self.pre_expiry(key, expiry)
+
+    def rpush(self, key, value):
+        self.emit('RPUSH', key, value)
+
+    def end_list(self, key):
+        self.post_expiry(key)
+
+    # Sorted set handling
+
+    def start_sorted_set(self, key, length, expiry, info):
+        self.pre_expiry(key, expiry)
+
+    def zadd(self, key, score, member):
+        self.emit('ZADD', key, score, member)
+
+    def end_sorted_set(self, key):
+        self.post_expiry(key)
+
+    # Other misc commands
+
+    def select(self, db_number):
+        self.emit('SELECT', db_number)
+
+    def expireat(self, key, timestamp):
+        self.emit('EXPIREAT', key, timestamp)

--- a/rdbtools/cli/rdb.py
+++ b/rdbtools/cli/rdb.py
@@ -2,7 +2,7 @@
 import os
 import sys
 from optparse import OptionParser
-from rdbtools import RdbParser, JSONCallback, DiffCallback, MemoryCallback, PrintAllKeys
+from rdbtools import RdbParser, JSONCallback, DiffCallback, MemoryCallback, ProtocolCallback, PrintAllKeys
 
 VALID_TYPES = ("hash", "set", "string", "list", "sortedset")
 def main():
@@ -12,8 +12,7 @@ Example : %prog --command json -k "user.*" /var/redis/6379/dump.rdb"""
 
     parser = OptionParser(usage=usage)
     parser.add_option("-c", "--command", dest="command",
-                  help="Command to execute. Valid commands are json or diff", metavar="FILE")
-                  
+                  help="Command to execute. Valid commands are json, diff, and protocol", metavar="FILE")
     parser.add_option("-f", "--file", dest="output",
                   help="Output file", metavar="FILE")
     parser.add_option("-n", "--db", dest="dbs", action="append",
@@ -60,8 +59,10 @@ Example : %prog --command json -k "user.*" /var/redis/6379/dump.rdb"""
             elif 'memory' == options.command:
                 reporter = PrintAllKeys(f)
                 callback = MemoryCallback(reporter, 64)
+            elif 'protocol' == options.command:
+                callback = ProtocolCallback(f)
             else:
-                raise Exception('Invalid Command %s' % options.output)
+                raise Exception('Invalid Command %s' % options.command)
             parser = RdbParser(callback)
             parser.parse(dump_file)
     else:
@@ -72,8 +73,10 @@ Example : %prog --command json -k "user.*" /var/redis/6379/dump.rdb"""
         elif 'memory' == options.command:
             reporter = PrintAllKeys(sys.stdout)
             callback = MemoryCallback(reporter, 64)
+        elif 'protocol' == options.command:
+            callback = ProtocolCallback(sys.stdout)
         else:
-            raise Exception('Invalid Command %s' % options.output)
+            raise Exception('Invalid Command %s' % options.command)
 
         parser = RdbParser(callback, filters=filters)
         parser.parse(dump_file)


### PR DESCRIPTION
I've added the ability to emit [Redis protocol](http://redis.io/topics/protocol) to the `rdb` command, so that it can be used with the `redis-cli --pipe` command.
