### PR TITLE
Added --size argument to filter keys by size

### DIFF
--- a/rdbtools/cli/rdb.py
+++ b/rdbtools/cli/rdb.py
@@ -22,6 +22,8 @@ Example : %prog --command json -k "user.*" /var/redis/6379/dump.rdb"""
     parser.add_option("-t", "--type", dest="types", action="append",
                   help="""Data types to include. Possible values are string, hash, set, sortedset, list. Multiple typees can be provided. 
                     If not specified, all data types will be returned""")
+    parser.add_option("-s", "--size", dest="size", default=None,
+                  help="Limit memory output to keys greater to or equal to this value (in bytes)")
     
     (options, args) = parser.parse_args()
     
@@ -57,7 +59,7 @@ Example : %prog --command json -k "user.*" /var/redis/6379/dump.rdb"""
             elif 'json' == options.command:
                 callback = JSONCallback(f)
             elif 'memory' == options.command:
-                reporter = PrintAllKeys(f)
+                reporter = PrintAllKeys(f, options.size)
                 callback = MemoryCallback(reporter, 64)
             elif 'protocol' == options.command:
                 callback = ProtocolCallback(f)
@@ -71,7 +73,7 @@ Example : %prog --command json -k "user.*" /var/redis/6379/dump.rdb"""
         elif 'json' == options.command:
             callback = JSONCallback(sys.stdout)
         elif 'memory' == options.command:
-            reporter = PrintAllKeys(sys.stdout)
+            reporter = PrintAllKeys(sys.stdout, options.size)
             callback = MemoryCallback(reporter, 64)
         elif 'protocol' == options.command:
             callback = ProtocolCallback(sys.stdout)

--- a/rdbtools/memprofiler.py
+++ b/rdbtools/memprofiler.py
@@ -68,14 +68,16 @@ class StatsAggregator():
         return json.dumps({"aggregates":self.aggregates, "scatters":self.scatters, "histograms":self.histograms})
         
 class PrintAllKeys():
-    def __init__(self, out):
+    def __init__(self, out, size):
+        self._size = int(size)
         self._out = out
         self._out.write("%s,%s,%s,%s,%s,%s,%s\n" % ("database", "type", "key", 
                                                  "size_in_bytes", "encoding", "num_elements", "len_largest_element"))
     
     def next_record(self, record) :
-        self._out.write("%d,%s,%s,%d,%s,%d,%d\n" % (record.database, record.type, encode_key(record.key), 
-                                                 record.bytes, record.encoding, record.size, record.len_largest_element))
+        if self._size is None or record.size >= self._size:
+            self._out.write("%d,%s,%s,%d,%s,%d,%d\n" % (record.database, record.type, encode_key(record.key), 
+                                                     record.bytes, record.encoding, record.size, record.len_largest_element))
     
 class MemoryCallback(RdbCallback):
     '''Calculates the memory used if this rdb file were loaded into RAM


### PR DESCRIPTION
I was profiling an rdb last night with over 2.4 million keys in it and well, LibreOffice wasn't too keen on me trying to open a CSV with that many rows. I added a new command line argument "--size" to allow me to set a minimum size (in bytes) to filter against to give me finer control on the output. Thought it was worth sharing, cheers!
