### PR TITLE
Hacking to allow handling of utf-8 encoded data

### DIFF
--- a/rdbtools/callbacks.py
+++ b/rdbtools/callbacks.py
@@ -295,8 +295,8 @@ class ProtocolCallback(RdbCallback):
     def emit(self, *args):
         self._out.write(u"*" + unicode(len(args)) + u"\r\n")
         for arg in args:
-            self._out.write(u"$" + unicode(len(unicode(arg))) + u"\r\n")
-            self._out.write(unicode(arg) + u"\r\n")
+            self._out.write(u"$" + unicode(len(unicode(str(arg), 'utf-8'))) + u"\r\n")
+            self._out.write(unicode(str(arg), 'utf-8') + u"\r\n")
 
     def start_database(self, db_number):
         self.reset()

--- a/rdbtools/callbacks.py
+++ b/rdbtools/callbacks.py
@@ -295,7 +295,7 @@ class ProtocolCallback(RdbCallback):
     def emit(self, *args):
         self._out.write(u"*" + unicode(len(args)) + u"\r\n")
         for arg in args:
-            self._out.write(u"$" + unicode(len(unicode(str(arg), 'utf-8'))) + u"\r\n")
+            self._out.write(u"$" + unicode(len(str(arg))) + u"\r\n")
             self._out.write(unicode(str(arg), 'utf-8') + u"\r\n")
 
     def start_database(self, db_number):

--- a/rdbtools/cli/rdb.py
+++ b/rdbtools/cli/rdb.py
@@ -4,6 +4,9 @@ import sys
 from optparse import OptionParser
 from rdbtools import RdbParser, JSONCallback, DiffCallback, MemoryCallback, ProtocolCallback, PrintAllKeys
 
+reload(sys)
+sys.setdefaultencoding('utf-8')
+
 VALID_TYPES = ("hash", "set", "string", "list", "sortedset")
 def main():
     usage = """usage: %prog [options] /path/to/dump.rdb


### PR DESCRIPTION
Hi there; first of all, thanks for your work and for opening it. It saved my day.

That said, I've got into some troubles with data encoded inside redid. Some of my utf-8 encoded strings in my dumps were causing the parser to crash, when doing things like:

rdb --command protocol --key "ru_RU"  dump.rdb

the change in callbacks.py is to allow those utf-8 data strings to be parsed. Without that change, I was facing

```
 UnicodeEncodeError: 'ascii' codec can't encode character u'\xa0' in position 0: ordinal not in range(128)
```

every time the parser ran into a utf-8 char (á, é, ñ...)

The change in rdb.py avoids a crash that happened only when launching in some consoles, and piping the output out to a file.

The fix are probably not good enough to be pulled, but I just thought they might be of help to avoid others will crash against the same wall I did.

Thanks!
