### PR TITLE
Clarified the expiry time format (Please validate the assumption before merging).

### DIFF
--- a/docs/RDB_File_Format.textile
+++ b/docs/RDB_File_Format.textile
@@ -72,8 +72,6 @@ This section starts with a one byte flag. A value of @FD@ indicates that the tim
 
 The next 4 bytes (or 8 bytes in case of @FC@) represents the timestamp at expiry. This is a unix timestamp and is in little endian format. 
 
-See the section "Redis Length Encoding" on how this number is encoded.
-
 During the import process, keys that have expired must be discarded.
 
 h4. Value Type

--- a/docs/RDB_File_Format.textile
+++ b/docs/RDB_File_Format.textile
@@ -68,9 +68,9 @@ Each key value pair has 4 parts -
 
 h4. Key Expiry Timestamp
 
-This section starts with a one byte flag. A value of @FD@ indicates expiry is specified in seconds. A value of @FC@ indicates expiry in specified in millseconds.
+This section starts with a one byte flag. A value of @FD@ indicates that the time of expiry is specified in seconds. A value of @FC@ indicates expiry in specified in millseconds.
 
-If time is specified in ms, the next 8 bytes represent the unix time  This number is a unix time stamp in either seconds or milliseconds precision, and represents the expiry of this key.
+The next 4 bytes (or 8 bytes in case of @FC@) represents the timestamp at expiry. This is a unix timestamp and is in little endian format. 
 
 See the section "Redis Length Encoding" on how this number is encoded.
 


### PR DESCRIPTION
1. Mentioned that the binary format for expiry is little endian.
2. The length encoding is 1byte, 2byte or max 5 byte (In which case we will ignore first byte). While I guess in case of expiry timestamp it is either 4 byte or 8 byte, both cases, the full length will represent the value. So, my assumption is that the expiry timestamp doesn't really represent the length encoding format (Please validate before merging). So, removed the reference to length encoding from expiry.
