### PR TITLE
added parse_stream method that parses file-like objects

### DIFF
--- a/tests/parser_tests.py
+++ b/tests/parser_tests.py
@@ -189,6 +189,13 @@ class RedisParserTestCase(unittest.TestCase):
         self.assertEquals(r.databases[0]['abcdef'], 'abcdef')
         self.assertEquals(r.databases[0]['longerstring'], 'thisisalongerstring.idontknowwhatitmeans')
 
+    def test_multiple_databases_stream(self):
+        r = load_rdb_stream('multiple_databases.rdb')
+        self.assert_(len(r.databases), 2)
+        self.assert_(1 not in r.databases)
+        self.assertEquals(r.databases[0]["key_in_zeroth_database"], "zero")
+        self.assertEquals(r.databases[2]["key_in_second_database"], "second")      
+
 def floateq(f1, f2) :
     return math.fabs(f1 - f2) < 0.00001
 
@@ -196,6 +203,12 @@ def load_rdb(file_name, filters=None) :
     r = MockRedis()
     parser = RdbParser(r, filters)
     parser.parse(os.path.join(os.path.dirname(__file__), 'dumps', file_name))
+    return r
+
+def load_rdb_stream(file_name, filters=None) :
+    r = MockRedis()
+    parser = RdbParser(r, filters)
+    parser.parse_stream(open(os.path.join(os.path.dirname(__file__), 'dumps', file_name), 'rb'))
     return r
     
 class MockRedis(RdbCallback):


### PR DESCRIPTION
I moved most of the code from the parse method in the parser to a new method parse_stream, which takes a file-like object as an argument.

This allows you to do something like:

    parser.parse_stream(sys.stdin)   #or any other file-like object

One of the reasons I wanted this, is so that I could do:

    pv /var/lib/redis/dump.rdb | ./main.py

And I get a nice progress bar as the file is being processed.

It shouldn't break anything, I also added a test for this functionality.