### PR TITLE
Update rdb.py to include "memory" as an option

### DIFF
--- a/rdbtools/cli/rdb.py
+++ b/rdbtools/cli/rdb.py
@@ -12,7 +12,7 @@ Example : %prog --command json -k "user.*" /var/redis/6379/dump.rdb"""
 
     parser = OptionParser(usage=usage)
     parser.add_option("-c", "--command", dest="command",
-                  help="Command to execute. Valid commands are json, diff, and protocol", metavar="FILE")
+                  help="Command to execute. Valid commands are json, diff, memory, and protocol", metavar="FILE")
     parser.add_option("-f", "--file", dest="output",
                   help="Output file", metavar="FILE")
     parser.add_option("-n", "--db", dest="dbs", action="append",


### PR DESCRIPTION
It looks it was missing in the help menu.