### PR TITLE
Fix ProtocolCallback.emit() unicode conversion to be content neutral.

### DIFF
--- a/rdbtools/callbacks.py
+++ b/rdbtools/callbacks.py
@@ -411,10 +411,11 @@ class ProtocolCallback(RdbCallback):
             self.expireat(key, self.get_expiry_seconds(key))
 
     def emit(self, *args):
-        self._out.write(u"*" + unicode(len(args)) + u"\r\n")
+        self._out.write("*{}\r\n".format(len(args)))
         for arg in args:
-            self._out.write(u"$" + unicode(len(unicode(arg))) + u"\r\n")
-            self._out.write(unicode(arg) + u"\r\n")
+            val = str(arg)
+            self._out.write("${}\r\n".format(len(val)))
+            self._out.write(val + "\r\n")
 
     def start_database(self, db_number):
         self.reset()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,9 +1,11 @@
 import unittest
 from tests.parser_tests import RedisParserTestCase
 from tests.memprofiler_tests import MemoryCallbackTestCase
+from tests.callbacks_tests import ProtocolTestCase
 
 def all_tests():
     suite = unittest.TestSuite()
     suite.addTest(unittest.makeSuite(RedisParserTestCase))
     suite.addTest(unittest.makeSuite(MemoryCallbackTestCase))
+    suite.addTest(unittest.makeSuite(ProtocolTestCase))
     return suite

--- a/tests/callbacks_tests.py
+++ b/tests/callbacks_tests.py
@@ -1,0 +1,20 @@
+import unittest
+import random
+from io import BytesIO
+from rdbtools.callbacks import ProtocolCallback
+
+
+class ProtocolTestCase(unittest.TestCase):
+    def setUp(self):
+        self._out = BytesIO()
+        self._callback = ProtocolCallback(self._out)
+
+    def test_emit(self):
+        utf8_string = '\xd9\xa1\xdf\x82\xe0\xa5\xa9\xe1\xa7\x94\xf0\x91\x8b\xb5'
+        bcde_non_print = '\x00\x01bcde\r\n\x88\x99'
+        random_bytes = ''.join(chr(random.randrange(0, 255)) for _ in range(64))
+        integer = 46
+        self._callback.emit(utf8_string, bcde_non_print, random_bytes, integer)
+        expected = '\r\n'.join(['*4', '$14', utf8_string, '$10', bcde_non_print, '$64', random_bytes, '$2', '46\r\n'])
+        result = self._out.getvalue()
+        self.assertEquals(result, expected)


### PR DESCRIPTION
Change [ProtocolCallback.emit()](https://github.com/sripathikrishnan/redis-rdb-tools/blob/9a344494de8ee6312681ac8d27b8804f4f992487/rdbtools/callbacks.py#L413) to use `str()` instead of `unicode()` so it will not try to convert string/byte content. This solves issues with parsing Unicode and binary data from RDB.

Code is partial taken from PRs #39 and #48, but solve their issues and add a test case.
Fix open issues: #45, #61, #66, and #75.