### PR TITLE
Handle float values in bytes escape functions

### DIFF
--- a/rdbtools/callbacks.py
+++ b/rdbtools/callbacks.py
@@ -2,7 +2,6 @@ import calendar
 import codecs
 import json
 
-from rdbtools.compat import isinteger
 from rdbtools.parser import RdbCallback
 from rdbtools import encodehelpers
 
@@ -240,7 +239,7 @@ class DiffCallback(RdbCallback):
         self._dbnum = 0
 
     def dbstr(self):
-        return b'db=' + encodehelpers.int2bytes(self._dbnum) + b' '
+        return b'db=' + encodehelpers.num2bytes(self._dbnum) + b' '
     def start_rdb(self):
         pass
     
@@ -282,7 +281,7 @@ class DiffCallback(RdbCallback):
         self._index = 0
             
     def rpush(self, key, value) :
-        istr = encodehelpers.int2bytes(self._index)
+        istr = encodehelpers.num2bytes(self._index)
         self._out.write(self.dbstr() + self.encode_key(key) + b'[' + istr + b'] -> ' + self.encode_value(value))
         self.newline()
         self._index = self._index + 1

--- a/rdbtools/compat.py
+++ b/rdbtools/compat.py
@@ -10,11 +10,11 @@ except NameError:
 
 try:
     long
-    def isinteger(n):
-        return isinstance(n, int) or isinstance(n, long)
+    def isnumber(n):
+        return isinstance(n, int) or isinstance(n, long) or isinstance(n, float)
 except NameError:
-    def isinteger(n):
-        return isinstance(n, int)
+    def isnumber(n):
+        return isinstance(n, int) or isinstance(n, float)
 
 if sys.version_info < (3,):
     def str2regexp(pattern):

--- a/rdbtools/encodehelpers.py
+++ b/rdbtools/encodehelpers.py
@@ -3,7 +3,7 @@ import base64
 import codecs
 import sys
 
-from .compat import isinteger
+from .compat import isnumber
 
 STRING_ESCAPE_RAW = 'raw'
 STRING_ESCAPE_PRINT = 'print'
@@ -14,14 +14,14 @@ ESCAPE_CHOICES = [STRING_ESCAPE_RAW, STRING_ESCAPE_PRINT, STRING_ESCAPE_UTF8, ST
 if sys.version_info < (3,):
     bval = ord
 
-    def int2unistr(i): return codecs.decode(str(i), 'ascii')
-    int2bytes = str
+    def num2unistr(i): return codecs.decode(str(i), 'ascii')
+    num2bytes = str
 else:
     def bval(x): return x
 
-    int2unistr = str
+    num2unistr = str
 
-    def int2bytes(i): return codecs.encode(str(i), 'ascii')
+    def num2bytes(i): return codecs.encode(str(i), 'ascii')
 
 ASCII_ESCAPE_LOOKUP = [u'\\x00', u'\\x01', u'\\x02', u'\\x03', u'\\x04', u'\\x05', u'\\x06', u'\\x07', u'\\x08',
                        u'\\x09', u'\\x0A', u'\\x0B', u'\\x0C', u'\\x0D', u'\\x0E', u'\\x0F', u'\\x10', u'\\x11',
@@ -101,11 +101,11 @@ def bytes_to_unicode(byte_data, escape, skip_printable=False):
     :param skip_printable: If True, don't escape byte_data with all 'printable ASCII' bytes. Defaults to False.
     :return: New unicode string, escaped with the specified method if needed.
     """
-    if isinteger(byte_data):
+    if isnumber(byte_data):
         if skip_printable:
-            return int2unistr(byte_data)
+            return num2unistr(byte_data)
         else:
-            byte_data = int2bytes(byte_data)
+            byte_data = num2bytes(byte_data)
     else:
         assert (isinstance(byte_data, type(b'')))
         if skip_printable and all(0x20 <= bval(ch) <= 0x7E for ch in byte_data):
@@ -132,11 +132,11 @@ def apply_escape_bytes(byte_data, escape, skip_printable=False):
     :return: new bytes object with the escaped bytes or byte_data itself on some no-op cases.
     """
 
-    if isinteger(byte_data):
+    if isnumber(byte_data):
         if skip_printable:
-            return int2bytes(byte_data)
+            return num2bytes(byte_data)
         else:
-            byte_data = int2bytes(byte_data)
+            byte_data = num2bytes(byte_data)
     else:
         assert (isinstance(byte_data, type(b'')))
         if skip_printable and all(0x20 <= bval(ch) <= 0x7E for ch in byte_data):

--- a/tests/callbacks_tests.py
+++ b/tests/callbacks_tests.py
@@ -1,3 +1,4 @@
+import glob
 import os
 import unittest
 import random
@@ -66,6 +67,22 @@ class CallbackTester(unittest.TestCase):
     def test_base64_escape(self):
         """Test using STRING_ESCAPE_BASE64 with varied key encodings against expected output."""
         self.escape_test_helper('STRING_ESCAPE_BASE64')
+
+    def test_all_dumps(self):
+        """Run callback with all test dumps intercepting incidental crashes."""
+        if self._callback_class is None:
+            return  # Handle unittest discovery attempt to test with this "abstract" class.
+
+        for dump_name in glob.glob(os.path.join(os.path.dirname(__file__), TEST_DUMPS_DIR, '*.rdb')):
+            callback = self._callback_class(out=self._out)
+            parser = RdbParser(callback)
+            try:
+                parser.parse(dump_name)
+            except Exception as err:
+                raise self.failureException("%s on %s - %s: %s" % (
+                    self._callback_class.__name__, os.path.basename(dump_name), type(err).__name__, str(err)))
+            self._out.seek(0)
+            self._out.truncate()
 
 
 class ProtocolTestCase(CallbackTester):


### PR DESCRIPTION
Fix #86 by adding float values handling on string escape functions.
`bytes_to_unicode` and `apply_escape_bytes` in encodehelpers.py assumed only integer and bytes values exist, ignoring floats. Now the handle floats in the same way integers are handled, by first converting to string.

While at it, also added a general test of running all built-in callbacks against all test dumps to cache any missed incidental crashes.
