### PR TITLE
Remove new string formatting to support Python2.6.9

### DIFF
--- a/rdbtools/callbacks.py
+++ b/rdbtools/callbacks.py
@@ -337,10 +337,10 @@ class ProtocolCallback(RdbCallback):
             self.expireat(key, self.get_expiry_seconds(key))
 
     def emit(self, *args):
-        self._out.write(codecs.encode("*{}\r\n".format(len(args)), 'ascii'))
+        self._out.write(codecs.encode("*%s\r\n" % len(args), 'ascii'))
         for arg in args:
             val = encodehelpers.apply_escape_bytes(arg, self._escape)
-            self._out.write(codecs.encode("${}\r\n".format(len(val)), 'ascii'))
+            self._out.write(codecs.encode("$%s\r\n" % len(val), 'ascii'))
             self._out.write(val + b"\r\n")
 
     def start_database(self, db_number):

--- a/rdbtools/cli/rdb.py
+++ b/rdbtools/cli/rdb.py
@@ -30,7 +30,7 @@ Example : %prog --command json -k "user.*" /var/redis/6379/dump.rdb"""
     parser.add_option("-l", "--largest", dest="largest", default=None,
                   help="Limit memory output to only the top N keys (by size)")
     parser.add_option("-e", "--escape", dest="escape", choices=ESCAPE_CHOICES,
-                      help="Escape strings to encoding: {} (default), {}, {}, or {}.".format(*ESCAPE_CHOICES))
+                      help="Escape strings to encoding: %s (default), %s, %s, or %s." % tuple(ESCAPE_CHOICES))
 
     (options, args) = parser.parse_args()
     


### PR DESCRIPTION
Fix Python2.6.9 support by replacing new style `{}` formatting with the previous `%` system.
The actual compatibility problem was using the new system with 'zero length field name'. I think dropping all use of new formatting emphasize this preference and will prevent future glitches.