### PR TITLE
Adding expiry to memory csv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ tests/dumps/dump_random_lists.rdb
 tests/dumps/dump_sorted_sets.rdb
 
 .idea/*
+venv2.6/
+venv2.7/
+venv3/

--- a/rdbtools/memprofiler.py
+++ b/rdbtools/memprofiler.py
@@ -304,6 +304,7 @@ class MemoryCallback(RdbCallback):
         self.end_key()
 
     def start_module(self, key, module_id, expiry):
+        self._key_expiry = expiry
         self._current_encoding = module_id
         self._current_size = self.top_level_object_overhead(key, expiry)
         self._current_size += 8 + 1  # add the module id length and EOF byte
@@ -312,7 +313,7 @@ class MemoryCallback(RdbCallback):
 
     def end_module(self, key, buffer_size, buffer=None):
         size = self._current_size + buffer_size
-        self.emit_record("module", key, size, self._current_encoding, 1, size, None)
+        self.emit_record("module", key, size, self._current_encoding, 1, size, self._key_expiry)
         self.end_key()
 
     def start_sorted_set(self, key, length, expiry, info):

--- a/rdbtools/parser.py
+++ b/rdbtools/parser.py
@@ -1026,5 +1026,3 @@ class DebugCallback(RdbCallback) :
     
     def end_rdb(self):
         print(']')
-
-

--- a/tests/memprofiler_tests.py
+++ b/tests/memprofiler_tests.py
@@ -18,6 +18,10 @@ CSV_WITHOUT_EXPIRY = """database,type,key,size_in_bytes,encoding,num_elements,le
 0,list,ziplist_compresses_easily,301,quicklist,6,36,
 """
 
+CSV_WITH_MODULE = """database,type,key,size_in_bytes,encoding,num_elements,len_largest_element,expiry
+0,string,simplekey,72,string,7,7,
+0,module,foo,101,ReJSON-RL,1,101,
+"""
 
 class Stats(object):
     def __init__(self):
@@ -54,6 +58,10 @@ class MemoryCallbackTestCase(unittest.TestCase):
     def test_csv_without_expiry(self):
         csv = get_csv('ziplist_that_compresses_easily.rdb')
         self.assertEquals(csv, CSV_WITHOUT_EXPIRY)
+
+    def test_csv_with_module(self):
+        csv = get_csv('redis_40_with_module.rdb')
+        self.assertEquals(csv, CSV_WITH_MODULE)
 
     def test_expiry(self):
         stats = get_stats('keys_with_expiry.rdb')

--- a/tests/memprofiler_tests.py
+++ b/tests/memprofiler_tests.py
@@ -1,10 +1,22 @@
+import sys
+import os
+from io import BytesIO
+
 import unittest
 
 from rdbtools import RdbParser
 from rdbtools import MemoryCallback
-import os
 
-from rdbtools.memprofiler import MemoryRecord
+
+from rdbtools.memprofiler import MemoryRecord, PrintAllKeys
+
+CSV_WITH_EXPIRY = """database,type,key,size_in_bytes,encoding,num_elements,len_largest_element,expiry
+0,string,expires_ms_precision,128,string,27,27,2022-12-25T10:11:12.573000
+"""
+
+CSV_WITHOUT_EXPIRY = """database,type,key,size_in_bytes,encoding,num_elements,len_largest_element,expiry
+0,list,ziplist_compresses_easily,301,quicklist,6,36,
+"""
 
 
 class Stats(object):
@@ -22,10 +34,38 @@ def get_stats(file_name):
     parser.parse(os.path.join(os.path.dirname(__file__), 'dumps', file_name))
     return stats.records
 
+def get_csv(dump_file_name):
+    buff = BytesIO()
+    callback = MemoryCallback(PrintAllKeys(buff, None, None), 64)
+    parser = RdbParser(callback)
+    parser.parse(os.path.join(os.path.dirname(__file__), 
+                    'dumps', dump_file_name))
+    csv = buff.getvalue().decode()
+    return csv
 
 class MemoryCallbackTestCase(unittest.TestCase):
     def setUp(self):
         pass
+
+    def test_csv_with_expiry(self):
+        csv = get_csv('keys_with_expiry.rdb')
+        self.assertEquals(csv, CSV_WITH_EXPIRY)
+
+    def test_csv_without_expiry(self):
+        csv = get_csv('ziplist_that_compresses_easily.rdb')
+        self.assertEquals(csv, CSV_WITHOUT_EXPIRY)
+
+    def test_expiry(self):
+        stats = get_stats('keys_with_expiry.rdb')
+
+        expiry = stats['expires_ms_precision'].expiry
+        self.assertEquals(expiry.year, 2022)
+        self.assertEquals(expiry.month, 12)
+        self.assertEquals(expiry.day, 25)
+        self.assertEquals(expiry.hour, 10)
+        self.assertEquals(expiry.minute, 11)
+        self.assertEquals(expiry.second, 12)
+        self.assertEquals(expiry.microsecond, 573000)        
 
     def test_len_largest_element(self):
         stats = get_stats('ziplist_that_compresses_easily.rdb')
@@ -39,5 +79,5 @@ class MemoryCallbackTestCase(unittest.TestCase):
         self.assertTrue('foo' in stats)
         expected_record = MemoryRecord(database=0, type='module', key='foo',
                                        bytes=101, encoding='ReJSON-RL', size=1,
-                                       len_largest_element=101)
+                                       len_largest_element=101, expiry=None)
         self.assertEquals(stats['foo'], expected_record)


### PR DESCRIPTION
This adds a new column called expiry to the memory csv file. This column contains the key expiry timestamp in ISO format. The timestamp is in UTC. For keys that don't have an expiry, this column is blank.

When analysing memory, it is useful to know if the key is ephemeral or permanent. Up until now, this information was missing. With this new column, it is now possible to aggregate keys on basis of expiry. For example, you can now identify that 50% of memory used is resident/never expires, 30% is set to expire in the next hour and so on.