### PR TITLE
Warn users when python-lzf is not installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,12 @@ Rdbtools is written in Python, though there are similar projects in other langua
 
 Pre-Requisites : 
 
+1. python-lzf is optional but highly recommended to speed up parsing.
 1. redis-py is optional and only needed to run test cases.
 
 To install from PyPI (recommended) :
 
-    pip install rdbtools
+    pip install rdbtools python-lzf
     
 To install from source : 
 

--- a/rdbtools/cli/rdb.py
+++ b/rdbtools/cli/rdb.py
@@ -4,6 +4,11 @@ import sys
 from optparse import OptionParser
 from rdbtools import RdbParser, JSONCallback, DiffCallback, MemoryCallback, ProtocolCallback, PrintAllKeys, KeysOnlyCallback, KeyValsOnlyCallback
 from rdbtools.encodehelpers import ESCAPE_CHOICES
+from rdbtools.parser import HAS_PYTHON_LZF as PYTHON_LZF_INSTALLED
+
+def eprint(*args, **kwargs):
+    """Print a string to the stderr stream"""
+    print(*args, file=sys.stderr, **kwargs)
 
 VALID_TYPES = ("hash", "set", "string", "list", "sortedset")
 def main():
@@ -81,6 +86,14 @@ Example : %prog --command json -k "user.*" /var/redis/6379/dump.rdb"""
             }[options.command](out_file_obj)
         except:
             raise Exception('Invalid Command %s' % options.command)
+
+        if not PYTHON_LZF_INSTALLED:
+            eprint("WARNING: python-lzf package NOT detected. " +
+                "Parsing dump file will be very slow unless you install it. " +
+                "To install, run the following command:")
+            eprint("")
+            eprint("pip install python-lzf")
+            eprint("")
 
         parser = RdbParser(callback, filters=filters)
         parser.parse(dump_file)


### PR DESCRIPTION
Decompressing LZF strings from the rdb file takes a significant amount of time. The python-lzf package is a native c module that significantly speeds up decompressing. Without this package, rdbtools uses a pure-python method to decompress string, and this is excruciatingly slow.

With this pull request, we update the readme to also install python-lzf from pip. Additionally, if we detect that lzf is not installed, we warn the users and provide instructions to install it.