### PR TITLE
 fix crash in parsing module data types containing floats

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,9 @@
+* 0.1.14
+    * fix parsing crash for rdb with module data containing floats
+    * fix memprofiler crash on python 2.x crash on long integers
+    * fix memprofiler crash on rdb with modules or streams
+    * improvements in memprofiler report to show totals and metadata
+
 * 0.1.13
     * Add support for rdb v9 (redis 5.0) and memory analysis of streams
     * Adding expiry to memory csv

--- a/rdbtools/__init__.py
+++ b/rdbtools/__init__.py
@@ -2,7 +2,7 @@ from rdbtools.parser import RdbCallback, RdbParser, DebugCallback
 from rdbtools.callbacks import JSONCallback, DiffCallback, ProtocolCallback, KeyValsOnlyCallback, KeysOnlyCallback
 from rdbtools.memprofiler import MemoryCallback, PrintAllKeys, StatsAggregator, PrintJustKeys
 
-__version__ = '0.1.13'
+__version__ = '0.1.14'
 VERSION = tuple(map(int, __version__.split('.')))
 
 __all__ = [

--- a/rdbtools/parser.py
+++ b/rdbtools/parser.py
@@ -558,7 +558,7 @@ class RdbParser(object):
             self._callback.start_sorted_set(self._key, length, self._expiry, info={'encoding':'skiplist','idle':self._idle,'freq':self._freq})
             for count in range(0, length):
                 val = self.read_string(f)
-                score = read_double(f) if enc_type == REDIS_RDB_TYPE_ZSET_2 else self.read_float(f)
+                score = read_binary_double(f) if enc_type == REDIS_RDB_TYPE_ZSET_2 else self.read_float(f)
                 self._callback.zadd(self._key, score, val)
             self._callback.end_sorted_set(self._key)
         elif enc_type == REDIS_RDB_TYPE_HASH:
@@ -825,9 +825,9 @@ class RdbParser(object):
             if opcode == REDIS_RDB_MODULE_OPCODE_SINT or opcode == REDIS_RDB_MODULE_OPCODE_UINT:
                 self.read_length(f)
             elif opcode == REDIS_RDB_MODULE_OPCODE_FLOAT:
-                self.skip_float(f)
+                read_binary_float(f)
             elif opcode == REDIS_RDB_MODULE_OPCODE_DOUBLE:
-                read_double(f)
+                read_binary_double(f)
             elif opcode == REDIS_RDB_MODULE_OPCODE_STRING:
                 self.skip_string(f)
             else:
@@ -851,9 +851,9 @@ class RdbParser(object):
             if opcode == REDIS_RDB_MODULE_OPCODE_SINT or opcode == REDIS_RDB_MODULE_OPCODE_UINT:
                 data = self.read_length(iowrapper)
             elif opcode == REDIS_RDB_MODULE_OPCODE_FLOAT:
-                data = self.read_float(iowrapper)
+                data = read_binary_float(iowrapper)
             elif opcode == REDIS_RDB_MODULE_OPCODE_DOUBLE:
-                data = read_double(iowrapper)
+                data = read_binary_double(iowrapper)
             elif opcode == REDIS_RDB_MODULE_OPCODE_STRING:
                 data = self.read_string(iowrapper)
             else:
@@ -1104,8 +1104,11 @@ def read_milliseconds_time(f) :
 def read_unsigned_long_be(f) :
     return struct.unpack('>Q', f.read(8))[0]
 
-def read_double(f) :
+def read_binary_double(f) :
     return struct.unpack('d', f.read(8))[0]
+
+def read_binary_float(f) :
+    return struct.unpack('f', f.read(4))[0]
 
 def string_as_hexcode(string) :
     for s in string :

--- a/rdbtools/templates/report.html.template
+++ b/rdbtools/templates/report.html.template
@@ -15,7 +15,10 @@
         google.setOnLoadCallback(draw_charts);
         
         function draw_charts() {
-            //draw_pie_chart('database_memory', chart_data.aggregates.database_memory, 'Database Number', 'Size in Bytes', 'Memory Usage by Database')
+            document.getElementById('database_memory').innerHTML = chart_data.aggregates.database_memory['all']
+            document.getElementById('aux_used_mem').innerHTML = chart_data.metadata.used_mem
+            document.getElementById('aux_redis_ver_and_bits').innerHTML = chart_data.metadata.redis_ver + ' - ' + chart_data.metadata.redis_bits + 'bit'
+            document.getElementById('internal_frag').innerHTML = chart_data.metadata.internal_frag
             
             draw_pie_chart('type_memory', chart_data.aggregates.type_memory, 'Data Type', 'Total Size in Bytes', 'Memory Usage by Data Type')
             draw_column_chart('type_count', chart_data.aggregates.type_count, 'Data Type', 'Keys', 'Number of Keys by Data Type')
@@ -105,14 +108,26 @@
   <body>
     <h1>Redis Memory Distribution for dump.rdb</h1>
     <div class="container">
-        <!--
+        <h2>Total database computed memory:</h2>
         <div class="row">
             <div class="span6" id="database_memory">
             </div>
-            <div class="span6" id="">
+        </div>
+        <h2>Total database memory from RDB aux field:</h2>
+        <div class="row">
+            <div class="span6" id="aux_used_mem">
             </div>
         </div>
-        -->
+        <h2>Database redis version and bits:</h2>
+        <div class="row">
+            <div class="span6" id="aux_redis_ver_and_bits">
+            </div>
+        </div>
+        <h2>Total estimated internal fragmentation:</h2>
+        <div class="row">
+            <div class="span6" id="internal_frag">
+            </div>
+        </div>
         <h2>Memory Usage By Data Type and Data Encoding</h2>
         <div class="row">
             <div class="span6" id="type_memory">


### PR DESCRIPTION
* modules save binary float, and not the old string based floats.
* fix crash in the memory profiler when handling rdb files with modules or streams
* improve memory report to contains the total estimated memory, and used_mem aux field, etc.
* and bump version for a release.