### PR TITLE
fixed bugs that skip_module doesn't read module id first

### DIFF
--- a/rdbtools/parser.py
+++ b/rdbtools/parser.py
@@ -820,6 +820,7 @@ class RdbParser(object):
             return None
 
     def skip_module(self, f):
+        self.read_length_with_encoding(f) # read module id first
         opcode = self.read_length(f)
         while opcode != REDIS_RDB_MODULE_OPCODE_EOF:
             if opcode == REDIS_RDB_MODULE_OPCODE_SINT or opcode == REDIS_RDB_MODULE_OPCODE_UINT:

--- a/tests/parser_tests.py
+++ b/tests/parser_tests.py
@@ -208,6 +208,10 @@ class RedisParserTestCase(unittest.TestCase):
         r = load_rdb('redis_40_with_module.rdb')
         self.assertEquals(r.databases[0][b'foo']['module_name'], 'ReJSON-RL')
 
+    def test_rdb_version_8_with_module_and_skip(self):
+        r = load_rdb('redis_40_with_module.rdb', {"keys": "bar"}) # skip foo module
+        self.assert_(b'foo' not in r.databases[0])
+
     def test_rdb_version_9_with_stream(self):
         r = load_rdb('redis_50_with_streams.rdb')
         self.assertEquals(r.lengths[0][b"mystream"], 4)


### PR DESCRIPTION
make test calls skip_module and make sure `module id` is read first in skip_module