### PR TITLE
Restoring a protocol snapshot without TTL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+dist: trusty
 python:
   - "2.6"
   - "2.7"

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ To limit the size of the files, you can filter on keys using the `--key` option
 
 You can convert RDB file into a stream of [redis protocol](http://redis.io/topics/protocol) using the `protocol` command.
 
-    > rdb --c protocol /var/redis/6379/dump.rdb
+    > rdb -c protocol /var/redis/6379/dump.rdb
     
     *4
     $4
@@ -171,6 +171,12 @@ and then pipe the output to a running redis instance to load that data.
 Read [Redis Mass Insert](http://redis.io/topics/mass-insert) for more information on this.
 
 When printing protocol output, the `--escape` option can be used with `printable` or `utf8` to avoid non printable/control characters.
+
+By default, expire times are emitted verbatim if they are present in the rdb file, causing all keys that expire in the past to be removed.
+If this behaviour is unwanted the `-x/--no-expire` option will ignore all key expiry commands.
+
+Otherwise you may want to set an expiry time in the future with `-a/--amend-expire` option which adds an integer number of seconds to the expiry time of each key which is already set to expire.
+This will not change keys that do not already have an expiry set.
 
 # Using the Parser ##
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,6 +2,7 @@ import unittest
 from tests.parser_tests import RedisParserTestCase
 from tests.memprofiler_tests import MemoryCallbackTestCase
 from tests.callbacks_tests import ProtocolTestCase, JsonTestCase, DiffTestCase, KeysTestCase, KeyValsTestCase
+from tests.protocol_tests import ProtocolExpireTestCase
 
 
 def all_tests():
@@ -12,7 +13,8 @@ def all_tests():
                       JsonTestCase,
                       DiffTestCase,
                       KeysTestCase,
-                      KeyValsTestCase]
+                      KeyValsTestCase,
+                      ProtocolExpireTestCase]
     for case in test_case_list:
         suite.addTest(unittest.makeSuite(case))
     return suite

--- a/tests/protocol_tests.py
+++ b/tests/protocol_tests.py
@@ -1,0 +1,57 @@
+import unittest
+import os
+import math
+from rdbtools import ProtocolCallback, RdbParser
+from io import BytesIO
+
+class ProtocolExpireTestCase(unittest.TestCase):
+    def setUp(self):
+        self.dumpfile = os.path.join(
+                os.path.dirname(__file__),
+                'dumps',
+                'keys_with_expiry.rdb')
+
+    def tearDown(self):
+        pass
+
+
+    def test_keys_with_expiry(self):
+        expected = (
+                b'*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n'
+                b'*3\r\n$3\r\nSET\r\n$20\r\nexpires_ms_precision\r\n'
+                b'$27\r\n2022-12-25 10:11:12.573 UTC\r\n'
+                b'*3\r\n$8\r\nEXPIREAT\r\n$20\r\nexpires_ms_precision\r\n'
+                b'$10\r\n1671963072\r\n'
+                )
+        buf = BytesIO()
+        parser = RdbParser(ProtocolCallback(buf))
+        parser.parse(self.dumpfile)
+        self.assertEquals(buf.getvalue(), expected)
+        
+
+    def test_amend_expiry(self):
+        expected = (
+                b'*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n'
+                b'*3\r\n$3\r\nSET\r\n$20\r\nexpires_ms_precision\r\n'
+                b'$27\r\n2022-12-25 10:11:12.573 UTC\r\n'
+                b'*3\r\n$8\r\nEXPIREAT\r\n$20\r\nexpires_ms_precision\r\n'
+                b'$10\r\n1671965072\r\n'
+                )
+        buf = BytesIO()
+        parser = RdbParser(ProtocolCallback(buf, amend_expire=2000))
+        parser.parse(self.dumpfile)
+        self.assertEquals(buf.getvalue(), expected)
+
+
+    def test_skip_expiry(self):
+        expected = (
+                b'*2\r\n$6\r\nSELECT\r\n$1\r\n0\r\n'
+                b'*3\r\n$3\r\nSET\r\n$20\r\nexpires_ms_precision\r\n'
+                b'$27\r\n2022-12-25 10:11:12.573 UTC\r\n'
+                )
+        buf = BytesIO()
+        parser = RdbParser(ProtocolCallback(buf, emit_expire=False))
+        parser.parse(self.dumpfile)
+        self.assertEquals(buf.getvalue(), expected)
+
+


### PR DESCRIPTION
I've added an option to the ProtocolCallback which skips setting the TTL on a key, even if it had an expiry set in the original .rdb file.

The reason for this is to copy a snapshot of a production redis instance where many keys are set to expire into a test redis instance where the keys can be safely examined.

Example usage, copying from a dump of a production database to a private redis running in Docker:

```
 ~/Projects/redis-rdb-tools $ rdb -c snapshot prod2.rdb | redis-cli -h 172.17.0.2 --pipe
```