### PR TITLE
parser_tests: replace self.assert_, self.assertEquals -> self.assertEqual

### DIFF
--- a/tests/memprofiler_tests.py
+++ b/tests/memprofiler_tests.py
@@ -65,27 +65,27 @@ class MemoryCallbackTestCase(unittest.TestCase):
 
     def test_csv_with_expiry(self):
         csv = get_csv('keys_with_expiry.rdb')
-        self.assertEquals(csv, CSV_WITH_EXPIRY)
+        self.assertEqual(csv, CSV_WITH_EXPIRY)
 
     def test_csv_without_expiry(self):
         csv = get_csv('ziplist_that_compresses_easily.rdb')
-        self.assertEquals(csv, CSV_WITHOUT_EXPIRY)
+        self.assertEqual(csv, CSV_WITHOUT_EXPIRY)
 
     def test_csv_with_module(self):
         csv = get_csv('redis_40_with_module.rdb')
-        self.assertEquals(csv, CSV_WITH_MODULE)
+        self.assertEqual(csv, CSV_WITH_MODULE)
 
     def test_expiry(self):
         stats = get_stats('keys_with_expiry.rdb')
 
         expiry = stats['expires_ms_precision'].expiry
-        self.assertEquals(expiry.year, 2022)
-        self.assertEquals(expiry.month, 12)
-        self.assertEquals(expiry.day, 25)
-        self.assertEquals(expiry.hour, 10)
-        self.assertEquals(expiry.minute, 11)
-        self.assertEquals(expiry.second, 12)
-        self.assertEquals(expiry.microsecond, 573000)        
+        self.assertEqual(expiry.year, 2022)
+        self.assertEqual(expiry.month, 12)
+        self.assertEqual(expiry.day, 25)
+        self.assertEqual(expiry.hour, 10)
+        self.assertEqual(expiry.minute, 11)
+        self.assertEqual(expiry.second, 12)
+        self.assertEqual(expiry.microsecond, 573000)
 
     def test_len_largest_element(self):
         stats = get_stats('ziplist_that_compresses_easily.rdb')
@@ -100,11 +100,11 @@ class MemoryCallbackTestCase(unittest.TestCase):
         expected_record = MemoryRecord(database=0, type='module', key='foo',
                                        bytes=101, encoding='ReJSON-RL', size=1,
                                        len_largest_element=101, expiry=None)
-        self.assertEquals(stats['foo'], expected_record)
+        self.assertEqual(stats['foo'], expected_record)
 
     def test_rdb_with_module_aux(self):
         sums = get_sums('redis_60_with_module_aux.rdb')
-        self.assertEquals(sums['module'], 32)
+        self.assertEqual(sums['module'], 32)
 
     def test_rdb_with_stream(self):
         stats = get_stats('redis_50_with_streams.rdb')
@@ -113,4 +113,4 @@ class MemoryCallbackTestCase(unittest.TestCase):
         expected_record = MemoryRecord(database=0, type='stream', key='mystream',
                                        bytes=1976, encoding='listpack', size=1,
                                        len_largest_element=184, expiry=None)
-        self.assertEquals(stats['mystream'], expected_record)
+        self.assertEqual(stats['mystream'], expected_record)

--- a/tests/parser_tests.py
+++ b/tests/parser_tests.py
@@ -15,54 +15,54 @@ class RedisParserTestCase(unittest.TestCase):
         r = load_rdb('empty_database.rdb')
         self.assertIn('start_rdb', r.methods_called)
         self.assertIn('end_rdb', r.methods_called)
-        self.assertEquals(len(r.databases), 0, msg = "didn't expect any databases")
+        self.assertEqual(len(r.databases), 0, msg = "didn't expect any databases")
 
     def test_multiple_databases(self):
         r = load_rdb('multiple_databases.rdb')
         self.assertEqual(len(r.databases), 2)
         self.assertNotIn(1, r.databases)
-        self.assertEquals(r.databases[0][b"key_in_zeroth_database"], b"zero")
-        self.assertEquals(r.databases[2][b"key_in_second_database"], b"second")
+        self.assertEqual(r.databases[0][b"key_in_zeroth_database"], b"zero")
+        self.assertEqual(r.databases[2][b"key_in_second_database"], b"second")
 
     def test_keys_with_expiry(self):
         r = load_rdb('keys_with_expiry.rdb')
         expiry = r.expiry[0][b'expires_ms_precision']
-        self.assertEquals(expiry.year, 2022)
-        self.assertEquals(expiry.month, 12)
-        self.assertEquals(expiry.day, 25)
-        self.assertEquals(expiry.hour, 10)
-        self.assertEquals(expiry.minute, 11)
-        self.assertEquals(expiry.second, 12)
-        self.assertEquals(expiry.microsecond, 573000)        
+        self.assertEqual(expiry.year, 2022)
+        self.assertEqual(expiry.month, 12)
+        self.assertEqual(expiry.day, 25)
+        self.assertEqual(expiry.hour, 10)
+        self.assertEqual(expiry.minute, 11)
+        self.assertEqual(expiry.second, 12)
+        self.assertEqual(expiry.microsecond, 573000)        
         
     def test_integer_keys(self):
         r = load_rdb('integer_keys.rdb')
-        self.assertEquals(r.databases[0][125], b"Positive 8 bit integer")
-        self.assertEquals(r.databases[0][0xABAB], b"Positive 16 bit integer")
-        self.assertEquals(r.databases[0][0x0AEDD325], b"Positive 32 bit integer")
+        self.assertEqual(r.databases[0][125], b"Positive 8 bit integer")
+        self.assertEqual(r.databases[0][0xABAB], b"Positive 16 bit integer")
+        self.assertEqual(r.databases[0][0x0AEDD325], b"Positive 32 bit integer")
 
     def test_negative_integer_keys(self):
         r = load_rdb('integer_keys.rdb')
-        self.assertEquals(r.databases[0][-123], b"Negative 8 bit integer")
-        self.assertEquals(r.databases[0][-0x7325], b"Negative 16 bit integer")
-        self.assertEquals(r.databases[0][-0x0AEDD325], b"Negative 32 bit integer")
+        self.assertEqual(r.databases[0][-123], b"Negative 8 bit integer")
+        self.assertEqual(r.databases[0][-0x7325], b"Negative 16 bit integer")
+        self.assertEqual(r.databases[0][-0x0AEDD325], b"Negative 32 bit integer")
 
     def test_string_key_with_compression(self):
         r = load_rdb('easily_compressible_string_key.rdb')
         key = b"".join(b'a' for x in range(0, 200))
         value = b"Key that redis should compress easily"
-        self.assertEquals(r.databases[0][key], value)
+        self.assertEqual(r.databases[0][key], value)
 
     def test_zipmap_thats_compresses_easily(self):
         r = load_rdb('zipmap_that_compresses_easily.rdb')
-        self.assertEquals(r.databases[0][b"zipmap_compresses_easily"][b"a"], b"aa")
-        self.assertEquals(r.databases[0][b"zipmap_compresses_easily"][b"aa"], b"aaaa")
-        self.assertEquals(r.databases[0][b"zipmap_compresses_easily"][b"aaaaa"], b"aaaaaaaaaaaaaa")
+        self.assertEqual(r.databases[0][b"zipmap_compresses_easily"][b"a"], b"aa")
+        self.assertEqual(r.databases[0][b"zipmap_compresses_easily"][b"aa"], b"aaaa")
+        self.assertEqual(r.databases[0][b"zipmap_compresses_easily"][b"aaaaa"], b"aaaaaaaaaaaaaa")
 
     def test_zipmap_that_doesnt_compress(self):
         r = load_rdb('zipmap_that_doesnt_compress.rdb')
-        self.assertEquals(r.databases[0][b"zimap_doesnt_compress"][b"MKD1G6"], 2)
-        self.assertEquals(r.databases[0][b"zimap_doesnt_compress"][b"YNNXK"], b"F7TI")
+        self.assertEqual(r.databases[0][b"zimap_doesnt_compress"][b"MKD1G6"], 2)
+        self.assertEqual(r.databases[0][b"zimap_doesnt_compress"][b"YNNXK"], b"F7TI")
 
     def test_zipmap_with_big_values(self):
         ''' See issue https://github.com/sripathikrishnan/redis-rdb-tools/issues/2
@@ -75,36 +75,36 @@ class RedisParserTestCase(unittest.TestCase):
             ziplist with a length encoding of 5 bytes.
         '''
         r = load_rdb('zipmap_with_big_values.rdb')
-        self.assertEquals(len(r.databases[0][b"zipmap_with_big_values"][b"253bytes"]), 253)
-        self.assertEquals(len(r.databases[0][b"zipmap_with_big_values"][b"254bytes"]), 254)
-        self.assertEquals(len(r.databases[0][b"zipmap_with_big_values"][b"255bytes"]), 255)
-        self.assertEquals(len(r.databases[0][b"zipmap_with_big_values"][b"300bytes"]), 300)
-        self.assertEquals(len(r.databases[0][b"zipmap_with_big_values"][b"20kbytes"]), 20000)
+        self.assertEqual(len(r.databases[0][b"zipmap_with_big_values"][b"253bytes"]), 253)
+        self.assertEqual(len(r.databases[0][b"zipmap_with_big_values"][b"254bytes"]), 254)
+        self.assertEqual(len(r.databases[0][b"zipmap_with_big_values"][b"255bytes"]), 255)
+        self.assertEqual(len(r.databases[0][b"zipmap_with_big_values"][b"300bytes"]), 300)
+        self.assertEqual(len(r.databases[0][b"zipmap_with_big_values"][b"20kbytes"]), 20000)
 
     def test_hash_as_ziplist(self):
         '''In redis dump version = 4, hashmaps are stored as ziplists'''
         r = load_rdb('hash_as_ziplist.rdb')
-        self.assertEquals(r.databases[0][b"zipmap_compresses_easily"][b"a"], b"aa")
-        self.assertEquals(r.databases[0][b"zipmap_compresses_easily"][b"aa"], b"aaaa")
-        self.assertEquals(r.databases[0][b"zipmap_compresses_easily"][b"aaaaa"], b"aaaaaaaaaaaaaa")
+        self.assertEqual(r.databases[0][b"zipmap_compresses_easily"][b"a"], b"aa")
+        self.assertEqual(r.databases[0][b"zipmap_compresses_easily"][b"aa"], b"aaaa")
+        self.assertEqual(r.databases[0][b"zipmap_compresses_easily"][b"aaaaa"], b"aaaaaaaaaaaaaa")
 
     def test_dictionary(self):
         r = load_rdb('dictionary.rdb')
-        self.assertEquals(r.lengths[0][b"force_dictionary"], 1000)
-        self.assertEquals(r.databases[0][b"force_dictionary"][b"ZMU5WEJDG7KU89AOG5LJT6K7HMNB3DEI43M6EYTJ83VRJ6XNXQ"],
+        self.assertEqual(r.lengths[0][b"force_dictionary"], 1000)
+        self.assertEqual(r.databases[0][b"force_dictionary"][b"ZMU5WEJDG7KU89AOG5LJT6K7HMNB3DEI43M6EYTJ83VRJ6XNXQ"],
                     b"T63SOS8DQJF0Q0VJEZ0D1IQFCYTIPSBOUIAI9SB0OV57MQR1FI")
-        self.assertEquals(r.databases[0][b"force_dictionary"][b"UHS5ESW4HLK8XOGTM39IK1SJEUGVV9WOPK6JYA5QBZSJU84491"],
+        self.assertEqual(r.databases[0][b"force_dictionary"][b"UHS5ESW4HLK8XOGTM39IK1SJEUGVV9WOPK6JYA5QBZSJU84491"],
                     b"6VULTCV52FXJ8MGVSFTZVAGK2JXZMGQ5F8OVJI0X6GEDDR27RZ")
 
     def test_ziplist_that_compresses_easily(self):
         r = load_rdb('ziplist_that_compresses_easily.rdb')
-        self.assertEquals(r.lengths[0][b"ziplist_compresses_easily"], 6)
+        self.assertEqual(r.lengths[0][b"ziplist_compresses_easily"], 6)
         for idx, length in enumerate([6, 12, 18, 24, 30, 36]) :
-            self.assertEquals((b"".join(b"a" for x in range(length))), r.databases[0][b"ziplist_compresses_easily"][idx])
+            self.assertEqual((b"".join(b"a" for x in range(length))), r.databases[0][b"ziplist_compresses_easily"][idx])
 
     def test_ziplist_that_doesnt_compress(self):
         r = load_rdb('ziplist_that_doesnt_compress.rdb')
-        self.assertEquals(r.lengths[0][b"ziplist_doesnt_compress"], 2)
+        self.assertEqual(r.lengths[0][b"ziplist_doesnt_compress"], 2)
         self.assertIn(b"aj2410", r.databases[0][b"ziplist_doesnt_compress"])
         self.assertIn(b"cc953a17a8e096e76a44169ad3f9ac87c5f8248a403274416179aa9fbd852344",
                       r.databases[0][b"ziplist_doesnt_compress"])
@@ -118,44 +118,44 @@ class RedisParserTestCase(unittest.TestCase):
         
         expected_numbers += [-2, 13, 25, -61, 63, 16380, -16000, 65535, -65523, 4194304, 0x7fffffffffffffff]
         
-        self.assertEquals(r.lengths[0][b"ziplist_with_integers"], len(expected_numbers))
+        self.assertEqual(r.lengths[0][b"ziplist_with_integers"], len(expected_numbers))
         
         for num in expected_numbers :
             self.assertIn(num, r.databases[0][b"ziplist_with_integers"], "Cannot find %d" % num)
 
     def test_linkedlist(self):
         r = load_rdb('linkedlist.rdb')
-        self.assertEquals(r.lengths[0][b"force_linkedlist"], 1000)
+        self.assertEqual(r.lengths[0][b"force_linkedlist"], 1000)
         self.assertIn(b"JYY4GIFI0ETHKP4VAJF5333082J4R1UPNPLE329YT0EYPGHSJQ", r.databases[0][b"force_linkedlist"])
         self.assertIn(b"TKBXHJOX9Q99ICF4V78XTCA2Y1UYW6ERL35JCIL1O0KSGXS58S", r.databases[0][b"force_linkedlist"])
 
     def test_intset_16(self):
         r = load_rdb('intset_16.rdb')
-        self.assertEquals(r.lengths[0][b"intset_16"], 3)
+        self.assertEqual(r.lengths[0][b"intset_16"], 3)
         for num in (0x7ffe, 0x7ffd, 0x7ffc) :
             self.assertIn(num, r.databases[0][b"intset_16"])
 
     def test_intset_32(self):
         r = load_rdb('intset_32.rdb')
-        self.assertEquals(r.lengths[0][b"intset_32"], 3)
+        self.assertEqual(r.lengths[0][b"intset_32"], 3)
         for num in (0x7ffefffe, 0x7ffefffd, 0x7ffefffc) :
             self.assertIn(num, r.databases[0][b"intset_32"])
 
     def test_intset_64(self):
         r = load_rdb('intset_64.rdb')
-        self.assertEquals(r.lengths[0][b"intset_64"], 3)
+        self.assertEqual(r.lengths[0][b"intset_64"], 3)
         for num in (0x7ffefffefffefffe, 0x7ffefffefffefffd, 0x7ffefffefffefffc) :
             self.assertIn(num, r.databases[0][b"intset_64"])
 
     def test_regular_set(self):
         r = load_rdb('regular_set.rdb')
-        self.assertEquals(r.lengths[0][b"regular_set"], 6)
+        self.assertEqual(r.lengths[0][b"regular_set"], 6)
         for member in (b"alpha", b"beta", b"gamma", b"delta", b"phi", b"kappa") :
             self.assertIn(member, r.databases[0][b"regular_set"], msg=('%s missing' % member))
 
     def test_sorted_set_as_ziplist(self):
         r = load_rdb('sorted_set_as_ziplist.rdb')
-        self.assertEquals(r.lengths[0][b"sorted_set_as_ziplist"], 3)
+        self.assertEqual(r.lengths[0][b"sorted_set_as_ziplist"], 3)
         zset = r.databases[0][b"sorted_set_as_ziplist"]
         self.assertTrue(floateq(zset[b'8b6ba6718a786daefa69438148361901'], 1))
         self.assertTrue(floateq(zset[b'cb7a24bb7528f934b841b34c3a73e0c7'], 2.37))
@@ -163,9 +163,9 @@ class RedisParserTestCase(unittest.TestCase):
 
     def test_filtering_by_keys(self):
         r = load_rdb('parser_filters.rdb', filters={"keys":"k[0-9]"})
-        self.assertEquals(r.databases[0][b'k1'], b"ssssssss")
-        self.assertEquals(r.databases[0][b'k3'], b"wwwwwwww")
-        self.assertEquals(len(r.databases[0]), 2)
+        self.assertEqual(r.databases[0][b'k1'], b"ssssssss")
+        self.assertEqual(r.databases[0][b'k3'], b"wwwwwwww")
+        self.assertEqual(len(r.databases[0]), 2)
 
     def test_filtering_by_type(self):
         r = load_rdb('parser_filters.rdb', filters={"types":["sortedset"]})
@@ -173,40 +173,40 @@ class RedisParserTestCase(unittest.TestCase):
         self.assertIn(b'z2', r.databases[0])
         self.assertIn(b'z3', r.databases[0])
         self.assertIn(b'z4', r.databases[0])
-        self.assertEquals(len(r.databases[0]), 4)
+        self.assertEqual(len(r.databases[0]), 4)
 
     def test_filtering_by_database(self):
         r = load_rdb('multiple_databases.rdb', filters={"dbs":[2]})
         self.assertNotIn(b'key_in_zeroth_database', r.databases[0])
         self.assertIn(b'key_in_second_database', r.databases[2])
-        self.assertEquals(len(r.databases[0]), 0)
-        self.assertEquals(len(r.databases[2]), 1)
+        self.assertEqual(len(r.databases[0]), 0)
+        self.assertEqual(len(r.databases[2]), 1)
 
     def test_rdb_version_5_with_checksum(self):
         r = load_rdb('rdb_version_5_with_checksum.rdb')
-        self.assertEquals(r.databases[0][b'abcd'], b'efgh')
-        self.assertEquals(r.databases[0][b'foo'], b'bar')
-        self.assertEquals(r.databases[0][b'bar'], b'baz')
-        self.assertEquals(r.databases[0][b'abcdef'], b'abcdef')
-        self.assertEquals(r.databases[0][b'longerstring'], b'thisisalongerstring.idontknowwhatitmeans')
+        self.assertEqual(r.databases[0][b'abcd'], b'efgh')
+        self.assertEqual(r.databases[0][b'foo'], b'bar')
+        self.assertEqual(r.databases[0][b'bar'], b'baz')
+        self.assertEqual(r.databases[0][b'abcdef'], b'abcdef')
+        self.assertEqual(r.databases[0][b'longerstring'], b'thisisalongerstring.idontknowwhatitmeans')
 
     def test_rdb_version_8_with_64b_length_and_scores(self):
         r = load_rdb('rdb_version_8_with_64b_length_and_scores.rdb')
-        self.assertEquals(r.databases[0][b'foo'], b'bar')
+        self.assertEqual(r.databases[0][b'foo'], b'bar')
         zset = r.databases[0][b"bigset"]
-        self.assertEquals(len(zset), 1000)
+        self.assertEqual(len(zset), 1000)
         self.assertTrue(floateq(zset[b'finalfield'], 2.718))
 
     def test_multiple_databases_stream(self):
         r = load_rdb_stream('multiple_databases.rdb')
-        self.assertEquals(len(r.databases), 2)
+        self.assertEqual(len(r.databases), 2)
         self.assertNotIn(1, r.databases)
-        self.assertEquals(r.databases[0][b"key_in_zeroth_database"], b"zero")
-        self.assertEquals(r.databases[2][b"key_in_second_database"], b"second")
+        self.assertEqual(r.databases[0][b"key_in_zeroth_database"], b"zero")
+        self.assertEqual(r.databases[2][b"key_in_second_database"], b"second")
 
     def test_rdb_version_8_with_module(self):
         r = load_rdb('redis_40_with_module.rdb')
-        self.assertEquals(r.databases[0][b'foo']['module_name'], 'ReJSON-RL')
+        self.assertEqual(r.databases[0][b'foo']['module_name'], 'ReJSON-RL')
 
     def test_rdb_version_8_with_module_and_skip(self):
         r = load_rdb('redis_40_with_module.rdb', {"keys": "bar"}) # skip foo module
@@ -214,8 +214,8 @@ class RedisParserTestCase(unittest.TestCase):
 
     def test_rdb_version_9_with_stream(self):
         r = load_rdb('redis_50_with_streams.rdb')
-        self.assertEquals(r.lengths[0][b"mystream"], 4)
-        self.assertEquals(len(r.databases[0][b'mystream']), 1)
+        self.assertEqual(r.lengths[0][b"mystream"], 4)
+        self.assertEqual(len(r.databases[0][b'mystream']), 1)
 
 
 def floateq(f1, f2) :

--- a/tests/parser_tests.py
+++ b/tests/parser_tests.py
@@ -13,14 +13,14 @@ class RedisParserTestCase(unittest.TestCase):
 
     def test_empty_rdb(self):
         r = load_rdb('empty_database.rdb')
-        self.assert_('start_rdb' in r.methods_called)
-        self.assert_('end_rdb' in r.methods_called)
+        self.assertIn('start_rdb', r.methods_called)
+        self.assertIn('end_rdb', r.methods_called)
         self.assertEquals(len(r.databases), 0, msg = "didn't expect any databases")
 
     def test_multiple_databases(self):
         r = load_rdb('multiple_databases.rdb')
-        self.assert_(len(r.databases), 2)
-        self.assert_(1 not in r.databases)
+        self.assertEqual(len(r.databases), 2)
+        self.assertNotIn(1, r.databases)
         self.assertEquals(r.databases[0][b"key_in_zeroth_database"], b"zero")
         self.assertEquals(r.databases[2][b"key_in_second_database"], b"second")
 
@@ -105,9 +105,9 @@ class RedisParserTestCase(unittest.TestCase):
     def test_ziplist_that_doesnt_compress(self):
         r = load_rdb('ziplist_that_doesnt_compress.rdb')
         self.assertEquals(r.lengths[0][b"ziplist_doesnt_compress"], 2)
-        self.assert_(b"aj2410" in r.databases[0][b"ziplist_doesnt_compress"])
-        self.assert_(b"cc953a17a8e096e76a44169ad3f9ac87c5f8248a403274416179aa9fbd852344"
-                        in r.databases[0][b"ziplist_doesnt_compress"])
+        self.assertIn(b"aj2410", r.databases[0][b"ziplist_doesnt_compress"])
+        self.assertIn(b"cc953a17a8e096e76a44169ad3f9ac87c5f8248a403274416179aa9fbd852344",
+                      r.databases[0][b"ziplist_doesnt_compress"])
 
     def test_ziplist_with_integers(self):
         r = load_rdb('ziplist_with_integers.rdb')
@@ -121,45 +121,45 @@ class RedisParserTestCase(unittest.TestCase):
         self.assertEquals(r.lengths[0][b"ziplist_with_integers"], len(expected_numbers))
         
         for num in expected_numbers :
-            self.assert_(num in r.databases[0][b"ziplist_with_integers"], "Cannot find %d" % num)
+            self.assertIn(num, r.databases[0][b"ziplist_with_integers"], "Cannot find %d" % num)
 
     def test_linkedlist(self):
         r = load_rdb('linkedlist.rdb')
         self.assertEquals(r.lengths[0][b"force_linkedlist"], 1000)
-        self.assert_(b"JYY4GIFI0ETHKP4VAJF5333082J4R1UPNPLE329YT0EYPGHSJQ" in r.databases[0][b"force_linkedlist"])
-        self.assert_(b"TKBXHJOX9Q99ICF4V78XTCA2Y1UYW6ERL35JCIL1O0KSGXS58S" in r.databases[0][b"force_linkedlist"])
+        self.assertIn(b"JYY4GIFI0ETHKP4VAJF5333082J4R1UPNPLE329YT0EYPGHSJQ", r.databases[0][b"force_linkedlist"])
+        self.assertIn(b"TKBXHJOX9Q99ICF4V78XTCA2Y1UYW6ERL35JCIL1O0KSGXS58S", r.databases[0][b"force_linkedlist"])
 
     def test_intset_16(self):
         r = load_rdb('intset_16.rdb')
         self.assertEquals(r.lengths[0][b"intset_16"], 3)
         for num in (0x7ffe, 0x7ffd, 0x7ffc) :
-            self.assert_(num in r.databases[0][b"intset_16"])
+            self.assertIn(num, r.databases[0][b"intset_16"])
 
     def test_intset_32(self):
         r = load_rdb('intset_32.rdb')
         self.assertEquals(r.lengths[0][b"intset_32"], 3)
         for num in (0x7ffefffe, 0x7ffefffd, 0x7ffefffc) :
-            self.assert_(num in r.databases[0][b"intset_32"])
+            self.assertIn(num, r.databases[0][b"intset_32"])
 
     def test_intset_64(self):
         r = load_rdb('intset_64.rdb')
         self.assertEquals(r.lengths[0][b"intset_64"], 3)
         for num in (0x7ffefffefffefffe, 0x7ffefffefffefffd, 0x7ffefffefffefffc) :
-            self.assert_(num in r.databases[0][b"intset_64"])
+            self.assertIn(num, r.databases[0][b"intset_64"])
 
     def test_regular_set(self):
         r = load_rdb('regular_set.rdb')
         self.assertEquals(r.lengths[0][b"regular_set"], 6)
         for member in (b"alpha", b"beta", b"gamma", b"delta", b"phi", b"kappa") :
-            self.assert_(member in r.databases[0][b"regular_set"], msg=('%s missing' % member))
+            self.assertIn(member, r.databases[0][b"regular_set"], msg=('%s missing' % member))
 
     def test_sorted_set_as_ziplist(self):
         r = load_rdb('sorted_set_as_ziplist.rdb')
         self.assertEquals(r.lengths[0][b"sorted_set_as_ziplist"], 3)
         zset = r.databases[0][b"sorted_set_as_ziplist"]
-        self.assert_(floateq(zset[b'8b6ba6718a786daefa69438148361901'], 1))
-        self.assert_(floateq(zset[b'cb7a24bb7528f934b841b34c3a73e0c7'], 2.37))
-        self.assert_(floateq(zset[b'523af537946b79c4f8369ed39ba78605'], 3.423))
+        self.assertTrue(floateq(zset[b'8b6ba6718a786daefa69438148361901'], 1))
+        self.assertTrue(floateq(zset[b'cb7a24bb7528f934b841b34c3a73e0c7'], 2.37))
+        self.assertTrue(floateq(zset[b'523af537946b79c4f8369ed39ba78605'], 3.423))
 
     def test_filtering_by_keys(self):
         r = load_rdb('parser_filters.rdb', filters={"keys":"k[0-9]"})
@@ -169,16 +169,16 @@ class RedisParserTestCase(unittest.TestCase):
 
     def test_filtering_by_type(self):
         r = load_rdb('parser_filters.rdb', filters={"types":["sortedset"]})
-        self.assert_(b'z1' in r.databases[0])
-        self.assert_(b'z2' in r.databases[0])
-        self.assert_(b'z3' in r.databases[0])
-        self.assert_(b'z4' in r.databases[0])
+        self.assertIn(b'z1', r.databases[0])
+        self.assertIn(b'z2', r.databases[0])
+        self.assertIn(b'z3', r.databases[0])
+        self.assertIn(b'z4', r.databases[0])
         self.assertEquals(len(r.databases[0]), 4)
 
     def test_filtering_by_database(self):
         r = load_rdb('multiple_databases.rdb', filters={"dbs":[2]})
-        self.assert_(b'key_in_zeroth_database' not in r.databases[0])
-        self.assert_(b'key_in_second_database' in r.databases[2])
+        self.assertNotIn(b'key_in_zeroth_database', r.databases[0])
+        self.assertIn(b'key_in_second_database', r.databases[2])
         self.assertEquals(len(r.databases[0]), 0)
         self.assertEquals(len(r.databases[2]), 1)
 
@@ -195,12 +195,12 @@ class RedisParserTestCase(unittest.TestCase):
         self.assertEquals(r.databases[0][b'foo'], b'bar')
         zset = r.databases[0][b"bigset"]
         self.assertEquals(len(zset), 1000)
-        self.assert_(floateq(zset[b'finalfield'], 2.718))
+        self.assertTrue(floateq(zset[b'finalfield'], 2.718))
 
     def test_multiple_databases_stream(self):
         r = load_rdb_stream('multiple_databases.rdb')
-        self.assert_(len(r.databases), 2)
-        self.assert_(1 not in r.databases)
+        self.assertEquals(len(r.databases), 2)
+        self.assertNotIn(1, r.databases)
         self.assertEquals(r.databases[0][b"key_in_zeroth_database"], b"zero")
         self.assertEquals(r.databases[2][b"key_in_second_database"], b"second")
 
@@ -210,7 +210,7 @@ class RedisParserTestCase(unittest.TestCase):
 
     def test_rdb_version_8_with_module_and_skip(self):
         r = load_rdb('redis_40_with_module.rdb', {"keys": "bar"}) # skip foo module
-        self.assert_(b'foo' not in r.databases[0])
+        self.assertNotIn(b'foo', r.databases[0])
 
     def test_rdb_version_9_with_stream(self):
         r = load_rdb('redis_50_with_streams.rdb')

--- a/tests/protocol_tests.py
+++ b/tests/protocol_tests.py
@@ -26,7 +26,7 @@ class ProtocolExpireTestCase(unittest.TestCase):
         buf = BytesIO()
         parser = RdbParser(ProtocolCallback(buf))
         parser.parse(self.dumpfile)
-        self.assertEquals(buf.getvalue(), expected)
+        self.assertEqual(buf.getvalue(), expected)
         
 
     def test_amend_expiry(self):
@@ -40,7 +40,7 @@ class ProtocolExpireTestCase(unittest.TestCase):
         buf = BytesIO()
         parser = RdbParser(ProtocolCallback(buf, amend_expire=2000))
         parser.parse(self.dumpfile)
-        self.assertEquals(buf.getvalue(), expected)
+        self.assertEqual(buf.getvalue(), expected)
 
 
     def test_skip_expiry(self):
@@ -52,6 +52,6 @@ class ProtocolExpireTestCase(unittest.TestCase):
         buf = BytesIO()
         parser = RdbParser(ProtocolCallback(buf, emit_expire=False))
         parser.parse(self.dumpfile)
-        self.assertEquals(buf.getvalue(), expected)
+        self.assertEqual(buf.getvalue(), expected)
 
 


### PR DESCRIPTION
This function does not exist (anymore?), use assert methods suitable for each type of check.

Also, `self.assertEquals` is called `self.assertEqual`.